### PR TITLE
[WIP] Update to RxSwift 2.0

### DIFF
--- a/Action.podspec
+++ b/Action.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |s|
   s.source_files  = "*.{swift}"
 
   s.frameworks  = "Foundation"
-  s.dependency "RxSwift", '~> 2.0.0-rc'
-  s.dependency "RxCocoa", '~> 2.0.0-rc'
+  s.dependency "RxSwift", '~> 2.0.0'
+  s.dependency "RxCocoa", '~> 2.0.0'
 
   s.watchos.exclude_files = "UIButton+Rx.swift", "UIBarButtonItem+Action.swift", "AlertAction.swift"
   s.osx.exclude_files = "UIButton+Rx.swift", "UIBarButtonItem+Action.swift", "AlertAction.swift"

--- a/Action.podspec
+++ b/Action.podspec
@@ -21,8 +21,8 @@ Pod::Spec.new do |s|
   s.source_files  = "*.{swift}"
 
   s.frameworks  = "Foundation"
-  s.dependency "RxSwift", '~> 2.0.0-beta'
-  s.dependency "RxCocoa", '~> 2.0.0-beta'
+  s.dependency "RxSwift", '~> 2.0.0-rc'
+  s.dependency "RxCocoa", '~> 2.0.0-rc'
 
   s.watchos.exclude_files = "UIButton+Rx.swift", "UIBarButtonItem+Action.swift", "AlertAction.swift"
   s.osx.exclude_files = "UIButton+Rx.swift", "UIBarButtonItem+Action.swift", "AlertAction.swift"

--- a/Action.swift
+++ b/Action.swift
@@ -67,7 +67,7 @@ public extension Action {
 
     /// Always enabled.
     public convenience init(workFactory: WorkFactory) {
-        self.init(enabledIf: just(true), workFactory: workFactory)
+        self.init(enabledIf: Observable.just(true), workFactory: workFactory)
     }
 }
 

--- a/Action.swift
+++ b/Action.swift
@@ -35,7 +35,7 @@ public final class Action<Input, Element> {
     /// Whether or not we're currently executing. 
     /// Always observed on MainScheduler.
     public var executing: Observable<Bool> {
-        return self._executing.asObservable().observeOn(MainScheduler.sharedInstance)
+        return self._executing.asObservable().observeOn(MainScheduler.instance)
     }
     private let _executing = Variable(false)
 
@@ -43,7 +43,7 @@ public final class Action<Input, Element> {
     /// property based on enabledIf initializer and if we're currently executing.
     /// Always observed on MainScheduler.
     public var enabled: Observable<Bool> {
-        return _enabled.asObservable().observeOn(MainScheduler.sharedInstance)
+        return _enabled.asObservable().observeOn(MainScheduler.instance)
     }
     public private(set) var _enabled = BehaviorSubject(value: true)
 

--- a/Action.swift
+++ b/Action.swift
@@ -56,7 +56,7 @@ public final class Action<Input, Element> {
         }
         self.workFactory = workFactory
 
-        combineLatest(self._enabledIf, self.executing) { (enabled, executing) -> Bool in
+        Observable.combineLatest(self._enabledIf, self.executing) { (enabled, executing) -> Bool in
             return enabled && !executing
         }.bindTo(_enabled).addDisposableTo(disposeBag)
     }

--- a/Action.swift
+++ b/Action.swift
@@ -67,7 +67,7 @@ public extension Action {
 
     /// Always enabled.
     public convenience init(workFactory: WorkFactory) {
-        self.init(enabledIf: Observable.just(true), workFactory: workFactory)
+        self.init(enabledIf: .just(true), workFactory: workFactory)
     }
 }
 

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -24,7 +24,7 @@ class ViewController: UIViewController {
         // Demo: add an action to a button in the view
         let action = CocoaAction {
 			print("Button was pressed, showing an alert and keeping the activity indicator spinning while alert is displayed")
-            return create {
+            return Observable.create {
 				[weak self] observer -> Disposable in
 
 				// Demo: show an alert and complete the view's button action once the alert's OK button is pressed

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController {
 				ok.rx_action = CocoaAction {
 					print("Alert's OK button was pressed")
 					observer.onCompleted()
-					return Observable.empty()
+					return .empty()
 				}
 				alertController.addAction(ok)
 				self!.presentViewController(alertController, animated: true, completion: nil)

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController {
 				ok.rx_action = CocoaAction {
 					print("Alert's OK button was pressed")
 					observer.onCompleted()
-					return empty()
+					return Observable.empty()
 				}
 				alertController.addAction(ok)
 				self!.presentViewController(alertController, animated: true, completion: nil)
@@ -46,7 +46,7 @@ class ViewController: UIViewController {
         // Demo: add an action to a UIBarButtonItem in the navigation item
         self.navigationItem.rightBarButtonItem!.rx_action = CocoaAction {
             print("Bar button item was pressed, simulating a 2 second action")
-            return empty().delaySubscription(2, MainScheduler.instance)
+            return Observable.empty().delaySubscription(2, MainScheduler.instance)
         }
 
         // Demo: observe the output of both actions, spin an activity indicator

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -51,7 +51,7 @@ class ViewController: UIViewController {
 
         // Demo: observe the output of both actions, spin an activity indicator
         // while performing the work
-        combineLatest(
+        Observable.combineLatest(
             button.rx_action!.executing,
             self.navigationItem.rightBarButtonItem!.rx_action!.executing) {
                 // we combine two boolean observable and output one boolean

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -46,7 +46,7 @@ class ViewController: UIViewController {
         // Demo: add an action to a UIBarButtonItem in the navigation item
         self.navigationItem.rightBarButtonItem!.rx_action = CocoaAction {
             print("Bar button item was pressed, simulating a 2 second action")
-            return empty().delaySubscription(2, MainScheduler.sharedInstance)
+            return empty().delaySubscription(2, MainScheduler.instance)
         }
 
         // Demo: observe the output of both actions, spin an activity indicator

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -46,7 +46,7 @@ class ViewController: UIViewController {
         // Demo: add an action to a UIBarButtonItem in the navigation item
         self.navigationItem.rightBarButtonItem!.rx_action = CocoaAction {
             print("Bar button item was pressed, simulating a 2 second action")
-            return Observable.empty().delaySubscription(2, MainScheduler.instance)
+            return Observable.empty().delaySubscription(2, scheduler: MainScheduler.instance)
         }
 
         // Demo: observe the output of both actions, spin an activity indicator

--- a/Demo/DemoTests/ActionTests.swift
+++ b/Demo/DemoTests/ActionTests.swift
@@ -121,7 +121,7 @@ class ActionTests: QuickSpec {
             var receivedInput: String?
             let subject = Action<String, Void>(workFactory: { (input) in
                 receivedInput = input
-                return Observable.just()
+                return .just()
             })
 
             subject.execute(testInput)
@@ -215,7 +215,7 @@ class ActionTests: QuickSpec {
             var invocations = 0
             let subject = Action<Void, Void>(workFactory: { _ in
                 invocations++
-                return Observable.empty()
+                return .empty()
             })
 
             subject.execute()
@@ -254,8 +254,8 @@ class ActionTests: QuickSpec {
 
         describe("disabled") {
             it("sends false on enabled observable") {
-                let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
-                    return Observable.empty()
+                let subject = Action<Void, Void>(enabledIf: .just(false), workFactory: { _ in
+                    return .empty()
                 })
 
                 let enabled = try! subject.enabled.toBlocking().first()
@@ -263,8 +263,8 @@ class ActionTests: QuickSpec {
             }
             
             it("errors observable sends error as next event when execute() is called") {
-                let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
-                    return Observable.empty()
+                let subject = Action<Void, Void>(enabledIf: .just(false), workFactory: { _ in
+                    return .empty()
                 })
 
                 var receivedError: ActionError?
@@ -282,8 +282,8 @@ class ActionTests: QuickSpec {
             }
 
             it("errors observable sends correct error types when execute() is called") {
-                let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
-                    return Observable.empty()
+                let subject = Action<Void, Void>(enabledIf: .just(false), workFactory: { _ in
+                    return .empty()
                 })
 
                 var receivedError: ActionError?
@@ -311,9 +311,9 @@ class ActionTests: QuickSpec {
             it("doesn't invoke the work factory") {
                 var invoked = false
 
-                let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
+                let subject = Action<Void, Void>(enabledIf: .just(false), workFactory: { _ in
                     invoked = true
-                    return Observable.empty()
+                    return .empty()
                 })
 
                 subject.execute()
@@ -330,7 +330,7 @@ extension String: ErrorType { }
 let TestError = "Test Error"
 
 func errorObservable() -> Observable<Void> {
-    return Observable.create({ (observer) -> Disposable in
+    return .create({ (observer) -> Disposable in
         observer.onError(TestError)
         return NopDisposable.instance
     })
@@ -344,7 +344,7 @@ func errorSubject() -> Action<Void, Void> {
 
 func emptySubject() -> Action<Void, Void> {
     return Action(workFactory: { input in
-        return Observable.empty()
+        return .empty()
     })
 }
 

--- a/Demo/DemoTests/ActionTests.swift
+++ b/Demo/DemoTests/ActionTests.swift
@@ -234,7 +234,7 @@ class ActionTests: QuickSpec {
             it("is externally disabled while executing") {
                 var observer: AnyObserver<Void>!
                 let subject = Action<Void, Void>(workFactory: { _ in
-                    return create { (obsv) -> Disposable in
+                    return Observable.create { (obsv) -> Disposable in
                         observer = obsv
                         return NopDisposable.instance
                     }
@@ -330,7 +330,7 @@ extension String: ErrorType { }
 let TestError = "Test Error"
 
 func errorObservable() -> Observable<Void> {
-    return create({ (observer) -> Disposable in
+    return Observable.create({ (observer) -> Disposable in
         observer.onError(TestError)
         return NopDisposable.instance
     })

--- a/Demo/DemoTests/ActionTests.swift
+++ b/Demo/DemoTests/ActionTests.swift
@@ -215,7 +215,7 @@ class ActionTests: QuickSpec {
             var invocations = 0
             let subject = Action<Void, Void>(workFactory: { _ in
                 invocations++
-                return empty()
+                return Observable.empty()
             })
 
             subject.execute()
@@ -255,7 +255,7 @@ class ActionTests: QuickSpec {
         describe("disabled") {
             it("sends false on enabled observable") {
                 let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
-                    return empty()
+                    return Observable.empty()
                 })
 
                 let enabled = try! subject.enabled.toBlocking().first()
@@ -264,7 +264,7 @@ class ActionTests: QuickSpec {
             
             it("errors observable sends error as next event when execute() is called") {
                 let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
-                    return empty()
+                    return Observable.empty()
                 })
 
                 var receivedError: ActionError?
@@ -283,7 +283,7 @@ class ActionTests: QuickSpec {
 
             it("errors observable sends correct error types when execute() is called") {
                 let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
-                    return empty()
+                    return Observable.empty()
                 })
 
                 var receivedError: ActionError?
@@ -313,7 +313,7 @@ class ActionTests: QuickSpec {
 
                 let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
                     invoked = true
-                    return empty()
+                    return Observable.empty()
                 })
 
                 subject.execute()
@@ -344,7 +344,7 @@ func errorSubject() -> Action<Void, Void> {
 
 func emptySubject() -> Action<Void, Void> {
     return Action(workFactory: { input in
-        return empty()
+        return Observable.empty()
     })
 }
 

--- a/Demo/DemoTests/ActionTests.swift
+++ b/Demo/DemoTests/ActionTests.swift
@@ -121,7 +121,7 @@ class ActionTests: QuickSpec {
             var receivedInput: String?
             let subject = Action<String, Void>(workFactory: { (input) in
                 receivedInput = input
-                return just()
+                return Observable.just()
             })
 
             subject.execute(testInput)
@@ -254,7 +254,7 @@ class ActionTests: QuickSpec {
 
         describe("disabled") {
             it("sends false on enabled observable") {
-                let subject = Action<Void, Void>(enabledIf: just(false), workFactory: { _ in
+                let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
                     return empty()
                 })
 
@@ -263,7 +263,7 @@ class ActionTests: QuickSpec {
             }
             
             it("errors observable sends error as next event when execute() is called") {
-                let subject = Action<Void, Void>(enabledIf: just(false), workFactory: { _ in
+                let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
                     return empty()
                 })
 
@@ -282,7 +282,7 @@ class ActionTests: QuickSpec {
             }
 
             it("errors observable sends correct error types when execute() is called") {
-                let subject = Action<Void, Void>(enabledIf: just(false), workFactory: { _ in
+                let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
                     return empty()
                 })
 
@@ -311,7 +311,7 @@ class ActionTests: QuickSpec {
             it("doesn't invoke the work factory") {
                 var invoked = false
 
-                let subject = Action<Void, Void>(enabledIf: just(false), workFactory: { _ in
+                let subject = Action<Void, Void>(enabledIf: Observable.just(false), workFactory: { _ in
                     invoked = true
                     return empty()
                 })

--- a/Demo/DemoTests/AlertActionTests.swift
+++ b/Demo/DemoTests/AlertActionTests.swift
@@ -43,8 +43,17 @@ class AlertActionTests: QuickSpec {
 
         it("disables the alert action if the Action is disabled") {
             let subject = UIAlertAction.Action("Hi", style: .Default)
+            let disposeBag = DisposeBag()
 
-            subject.rx_action = emptyAction(Observable.just(false))
+            subject.rx_action = emptyAction(.just(false))
+            waitUntil { done in
+                subject.rx_observe(Bool.self, "enabled")
+                    .take(1)
+                    .subscribeNext { _ in
+                        done()
+                    }
+                    .addDisposableTo(disposeBag)
+            }
 
             expect(subject.enabled) == false
         }

--- a/Demo/DemoTests/AlertActionTests.swift
+++ b/Demo/DemoTests/AlertActionTests.swift
@@ -26,7 +26,7 @@ class AlertActionTests: QuickSpec {
 
             var observer: AnyObserver<Void>!
             let action = CocoaAction(workFactory: { _ in
-                return create { (obsv) -> Disposable in
+                return Observable.create { (obsv) -> Disposable in
                     observer = obsv
                     return NopDisposable.instance
                 }

--- a/Demo/DemoTests/AlertActionTests.swift
+++ b/Demo/DemoTests/AlertActionTests.swift
@@ -44,7 +44,7 @@ class AlertActionTests: QuickSpec {
         it("disables the button if the Action is disabled") {
             let subject = UIAlertAction.Action("Hi", style: .Default)
 
-            subject.rx_action = emptyAction(just(false))
+            subject.rx_action = emptyAction(Observable.just(false))
 
             expect(subject.enabled) == false
         }

--- a/Demo/DemoTests/AlertActionTests.swift
+++ b/Demo/DemoTests/AlertActionTests.swift
@@ -21,7 +21,7 @@ class AlertActionTests: QuickSpec {
             expect(subject.rx_action) === action
         }
 
-        it("disables the button while executing") {
+        it("disables the alert action while executing") {
             let subject = UIAlertAction.Action("Hi", style: .Default)
 
             var observer: AnyObserver<Void>!
@@ -41,7 +41,7 @@ class AlertActionTests: QuickSpec {
             expect(subject.enabled).toEventually( beTrue() )
         }
 
-        it("disables the button if the Action is disabled") {
+        it("disables the alert action if the Action is disabled") {
             let subject = UIAlertAction.Action("Hi", style: .Default)
 
             subject.rx_action = emptyAction(Observable.just(false))

--- a/Demo/DemoTests/BarButtonTests.swift
+++ b/Demo/DemoTests/BarButtonTests.swift
@@ -45,7 +45,7 @@ class BarButtonTests: QuickSpec {
 		it("disables the button if the Action is disabled") {
 			let subject = UIBarButtonItem(barButtonSystemItem: .Save, target: nil, action: nil)
 			
-			subject.rx_action = emptyAction(Observable.just(false))
+			subject.rx_action = emptyAction(.just(false))
 			
 			expect(subject.enabled) == false
 		}
@@ -54,9 +54,9 @@ class BarButtonTests: QuickSpec {
 			let subject = UIBarButtonItem(barButtonSystemItem: .Save, target: nil, action: nil)
 			
 			var executed = false
-			subject.rx_action = CocoaAction(enabledIf: Observable.just(false), workFactory: { _ in
+			subject.rx_action = CocoaAction(enabledIf: .just(false), workFactory: { _ in
 				executed = true
-				return Observable.empty()
+				return .empty()
 			})
 			
 			subject.target?.performSelector(subject.action, withObject: subject)
@@ -70,7 +70,7 @@ class BarButtonTests: QuickSpec {
 			var executed = false
 			let action = CocoaAction(workFactory: { _ in
 				executed = true
-				return Observable.empty()
+				return .empty()
 			})
 			subject.rx_action = action
 			

--- a/Demo/DemoTests/BarButtonTests.swift
+++ b/Demo/DemoTests/BarButtonTests.swift
@@ -56,7 +56,7 @@ class BarButtonTests: QuickSpec {
 			var executed = false
 			subject.rx_action = CocoaAction(enabledIf: Observable.just(false), workFactory: { _ in
 				executed = true
-				return empty()
+				return Observable.empty()
 			})
 			
 			subject.target?.performSelector(subject.action, withObject: subject)
@@ -70,7 +70,7 @@ class BarButtonTests: QuickSpec {
 			var executed = false
 			let action = CocoaAction(workFactory: { _ in
 				executed = true
-				return empty()
+				return Observable.empty()
 			})
 			subject.rx_action = action
 			

--- a/Demo/DemoTests/BarButtonTests.swift
+++ b/Demo/DemoTests/BarButtonTests.swift
@@ -27,7 +27,7 @@ class BarButtonTests: QuickSpec {
 			
 			var observer: AnyObserver<Void>!
 			let action = CocoaAction(workFactory: { _ in
-				return create { (obsv) -> Disposable in
+				return Observable.create { (obsv) -> Disposable in
 					observer = obsv
 					return NopDisposable.instance
 				}

--- a/Demo/DemoTests/BarButtonTests.swift
+++ b/Demo/DemoTests/BarButtonTests.swift
@@ -45,7 +45,7 @@ class BarButtonTests: QuickSpec {
 		it("disables the button if the Action is disabled") {
 			let subject = UIBarButtonItem(barButtonSystemItem: .Save, target: nil, action: nil)
 			
-			subject.rx_action = emptyAction(just(false))
+			subject.rx_action = emptyAction(Observable.just(false))
 			
 			expect(subject.enabled) == false
 		}
@@ -54,7 +54,7 @@ class BarButtonTests: QuickSpec {
 			let subject = UIBarButtonItem(barButtonSystemItem: .Save, target: nil, action: nil)
 			
 			var executed = false
-			subject.rx_action = CocoaAction(enabledIf: just(false), workFactory: { _ in
+			subject.rx_action = CocoaAction(enabledIf: Observable.just(false), workFactory: { _ in
 				executed = true
 				return empty()
 			})

--- a/Demo/DemoTests/ButtonTests.swift
+++ b/Demo/DemoTests/ButtonTests.swift
@@ -27,7 +27,7 @@ class ButtonTests: QuickSpec {
 
             var observer: AnyObserver<Void>!
             let action = CocoaAction(workFactory: { _ in
-                return create { (obsv) -> Disposable in
+                return Observable.create { (obsv) -> Disposable in
                     observer = obsv
                     return NopDisposable.instance
                 }

--- a/Demo/DemoTests/ButtonTests.swift
+++ b/Demo/DemoTests/ButtonTests.swift
@@ -45,7 +45,7 @@ class ButtonTests: QuickSpec {
         it("disables the button if the Action is disabled") {
             let subject = UIButton(type: .System)
 
-            subject.rx_action = emptyAction(Observable.just(false))
+            subject.rx_action = emptyAction(.just(false))
             
             expect(subject.enabled) == false
         }
@@ -54,9 +54,9 @@ class ButtonTests: QuickSpec {
             let subject = UIButton(type: .System)
 
             var executed = false
-            subject.rx_action = CocoaAction(enabledIf: Observable.just(false), workFactory: { _ in
+            subject.rx_action = CocoaAction(enabledIf: .just(false), workFactory: { _ in
                 executed = true
-                return Observable.empty()
+                return .empty()
             })
 
             subject.sendActionsForControlEvents(.TouchUpInside)
@@ -70,7 +70,7 @@ class ButtonTests: QuickSpec {
             var executed = false
             let action = CocoaAction(workFactory: { _ in
                 executed = true
-                return Observable.empty()
+                return .empty()
             })
             subject.rx_action = action
 
@@ -109,8 +109,8 @@ class ButtonTests: QuickSpec {
     }
 }
 
-func emptyAction(enabledIf: Observable<Bool> = Observable.just(true)) -> CocoaAction {
+func emptyAction(enabledIf: Observable<Bool> = .just(true)) -> CocoaAction {
     return CocoaAction(enabledIf: enabledIf, workFactory: { _ in
-        return Observable.empty()
+        return .empty()
     })
 }

--- a/Demo/DemoTests/ButtonTests.swift
+++ b/Demo/DemoTests/ButtonTests.swift
@@ -56,7 +56,7 @@ class ButtonTests: QuickSpec {
             var executed = false
             subject.rx_action = CocoaAction(enabledIf: Observable.just(false), workFactory: { _ in
                 executed = true
-                return empty()
+                return Observable.empty()
             })
 
             subject.sendActionsForControlEvents(.TouchUpInside)
@@ -70,7 +70,7 @@ class ButtonTests: QuickSpec {
             var executed = false
             let action = CocoaAction(workFactory: { _ in
                 executed = true
-                return empty()
+                return Observable.empty()
             })
             subject.rx_action = action
 
@@ -111,6 +111,6 @@ class ButtonTests: QuickSpec {
 
 func emptyAction(enabledIf: Observable<Bool> = Observable.just(true)) -> CocoaAction {
     return CocoaAction(enabledIf: enabledIf, workFactory: { _ in
-        return empty()
+        return Observable.empty()
     })
 }

--- a/Demo/DemoTests/ButtonTests.swift
+++ b/Demo/DemoTests/ButtonTests.swift
@@ -45,7 +45,7 @@ class ButtonTests: QuickSpec {
         it("disables the button if the Action is disabled") {
             let subject = UIButton(type: .System)
 
-            subject.rx_action = emptyAction(just(false))
+            subject.rx_action = emptyAction(Observable.just(false))
             
             expect(subject.enabled) == false
         }
@@ -54,7 +54,7 @@ class ButtonTests: QuickSpec {
             let subject = UIButton(type: .System)
 
             var executed = false
-            subject.rx_action = CocoaAction(enabledIf: just(false), workFactory: { _ in
+            subject.rx_action = CocoaAction(enabledIf: Observable.just(false), workFactory: { _ in
                 executed = true
                 return empty()
             })
@@ -109,7 +109,7 @@ class ButtonTests: QuickSpec {
     }
 }
 
-func emptyAction(enabledIf: Observable<Bool> = just(true)) -> CocoaAction {
+func emptyAction(enabledIf: Observable<Bool> = Observable.just(true)) -> CocoaAction {
     return CocoaAction(enabledIf: enabledIf, workFactory: { _ in
         return empty()
     })

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -17,9 +17,9 @@ end
 target 'DemoTests' do
 
 # Dependencies
-pod 'RxSwift', '~> 2.0.0-rc'
-pod 'RxCocoa', '~> 2.0.0-rc'
-pod 'RxBlocking', '~> 2.0.0-rc'
+pod 'RxSwift', '~> 2.0.0'
+pod 'RxCocoa', '~> 2.0.0'
+pod 'RxBlocking', '~> 2.0.0'
 
 # Testing libraries
 pod 'Quick'

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -17,9 +17,9 @@ end
 target 'DemoTests' do
 
 # Dependencies
-pod 'RxSwift', '~> 2.0.0-beta'
-pod 'RxCocoa', '~> 2.0.0-beta'
-pod 'RxBlocking', '~> 2.0.0-beta'
+pod 'RxSwift', '~> 2.0.0-rc'
+pod 'RxCocoa', '~> 2.0.0-rc'
+pod 'RxBlocking', '~> 2.0.0-rc'
 
 # Testing libraries
 pod 'Quick'

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,33 +1,33 @@
 PODS:
   - Action (1.0.0):
-    - RxCocoa (~> 2.0.0-rc)
-    - RxSwift (~> 2.0.0-rc)
+    - RxCocoa (~> 2.0.0)
+    - RxSwift (~> 2.0.0)
   - Nimble (3.0.0)
   - Quick (0.8.0)
-  - RxBlocking (2.0.0-rc.0):
-    - RxSwift (~> 2.0.0-rc)
-  - RxCocoa (2.0.0-rc.0):
-    - RxSwift (~> 2.0.0-rc)
-  - RxSwift (2.0.0-rc.0)
+  - RxBlocking (2.0.0):
+    - RxSwift (~> 2.0)
+  - RxCocoa (2.0.0):
+    - RxSwift (~> 2.0)
+  - RxSwift (2.0.0)
 
 DEPENDENCIES:
   - Action (from `../`)
   - Nimble
   - Quick
-  - RxBlocking (~> 2.0.0-rc)
-  - RxCocoa (~> 2.0.0-rc)
-  - RxSwift (~> 2.0.0-rc)
+  - RxBlocking (~> 2.0.0)
+  - RxCocoa (~> 2.0.0)
+  - RxSwift (~> 2.0.0)
 
 EXTERNAL SOURCES:
   Action:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Action: 5d3be0b930dd0ddb362638dad3b9ae0390917053
+  Action: 6e9b1bb31f75cf7092b07d4acfaf8e217393b180
   Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
   Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
-  RxBlocking: 4ed027a5307c2c5bec9c89bf2da6c9e24ca3042c
-  RxCocoa: 480daa33d88e6d21f4686b975dcf9f2ebe17ac25
-  RxSwift: b8452e54c1da42dbd7e12167c606911c0cd29b49
+  RxBlocking: a95a10ed54eb5d116f6c9a87047ff671e181d07b
+  RxCocoa: b0ebd70b4f7450bdb3c8987b122f8fd568dc1e2f
+  RxSwift: d83246efa6f16c50c143bec134649d045498f601
 
 COCOAPODS: 0.39.0

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -14,9 +14,9 @@ DEPENDENCIES:
   - Action (from `../`)
   - Nimble
   - Quick
-  - RxBlocking (~> 2.0.0-beta)
-  - RxCocoa (~> 2.0.0-beta)
-  - RxSwift (~> 2.0.0-beta)
+  - RxBlocking (~> 2.0.0-rc)
+  - RxCocoa (~> 2.0.0-rc)
+  - RxSwift (~> 2.0.0-rc)
 
 EXTERNAL SOURCES:
   Action:

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Action (0.3.0):
-    - RxCocoa (~> 2.0.0-beta)
-    - RxSwift (~> 2.0.0-beta)
+  - Action (1.0.0):
+    - RxCocoa (~> 2.0.0-rc)
+    - RxSwift (~> 2.0.0-rc)
   - Nimble (3.0.0)
   - Quick (0.8.0)
-  - RxBlocking (2.0.0-beta.4):
-    - RxSwift (~> 2.0.0-beta)
-  - RxCocoa (2.0.0-beta.4):
-    - RxSwift (~> 2.0.0-beta)
-  - RxSwift (2.0.0-beta.4)
+  - RxBlocking (2.0.0-rc.0):
+    - RxSwift (~> 2.0.0-rc)
+  - RxCocoa (2.0.0-rc.0):
+    - RxSwift (~> 2.0.0-rc)
+  - RxSwift (2.0.0-rc.0)
 
 DEPENDENCIES:
   - Action (from `../`)
@@ -23,11 +23,11 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Action: da3ac4ae245c10f909fd07db34680a90beb4aa21
+  Action: 5d3be0b930dd0ddb362638dad3b9ae0390917053
   Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
   Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
-  RxBlocking: 234b0c161315ff3ade25c11e48d74e9ca83158b5
-  RxCocoa: 4a3e433e6dfe116362ff54423c841cc0f209e009
-  RxSwift: 191c6b06da783a8671433cf35a54d2ad2fd2d9de
+  RxBlocking: 4ed027a5307c2c5bec9c89bf2da6c9e24ca3042c
+  RxCocoa: 480daa33d88e6d21f4686b975dcf9f2ebe17ac25
+  RxSwift: b8452e54c1da42dbd7e12167c606911c0cd29b49
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
* [x] `just` -> `Observable.just`
* [x] `Variable` is no longer a direct `ObservableType`
  * Didn't affect us as we were already bridging it to an `Observable`.
* [x] `empty()` -> `Observable.empty`
* [x] `MainScheduler.sharedInstance` -> `MainScheduler.instance`
* [x] `create` -> `Observable.create`
* [x] `combineLatest` -> `Observable.combineLatest`
Refs #18 