### PR TITLE
Update Action to RXSwift 2.2.0

### DIFF
--- a/Action.podspec
+++ b/Action.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Action"
-  s.version      = "1.2.0"
+  s.version      = "1.3.0"
   s.summary      = "Abstracts actions to be performed in RxSwift."
   s.description  = <<-DESC
     Encapsulates an action to be performed, usually by a UIButton press.
@@ -21,8 +21,8 @@ Pod::Spec.new do |s|
   s.source_files  = "*.{swift}"
 
   s.frameworks  = "Foundation"
-  s.dependency "RxSwift", '~> 2.0'
-  s.dependency "RxCocoa", '~> 2.0'
+  s.dependency "RxSwift", '~> 2.2.0'
+  s.dependency "RxCocoa", '~> 2.2.0'
 
   s.watchos.exclude_files = "UIButton+Rx.swift", "UIBarButtonItem+Action.swift", "AlertAction.swift"
   s.osx.exclude_files = "UIButton+Rx.swift", "UIBarButtonItem+Action.swift", "AlertAction.swift"

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@ Changelog
 Current master
 --------------
 
+1.3.0
+-----
+
+- Updates to RxSwift 2.2.0.
+
 1.2.0
 -----
 

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -17,9 +17,9 @@ end
 target 'DemoTests' do
 
 # Dependencies
-pod 'RxSwift', '~> 2.1'
-pod 'RxCocoa', '~> 2.1'
-pod 'RxBlocking', '~> 2.1'
+pod 'RxSwift', '~> 2.2'
+pod 'RxCocoa', '~> 2.2'
+pod 'RxBlocking', '~> 2.2'
 
 # Testing libraries
 pod 'Quick'

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,33 +1,33 @@
 PODS:
-  - Action (1.1.0):
-    - RxCocoa (~> 2.1.0)
-    - RxSwift (~> 2.1.0)
+  - Action (1.3.0):
+    - RxCocoa (~> 2.2.0)
+    - RxSwift (~> 2.2.0)
   - Nimble (3.0.0)
   - Quick (0.8.0)
-  - RxBlocking (2.1.0):
-    - RxSwift (~> 2.0)
-  - RxCocoa (2.1.0):
-    - RxSwift (~> 2.0)
-  - RxSwift (2.1.0)
+  - RxBlocking (2.2.0):
+    - RxSwift (~> 2.2)
+  - RxCocoa (2.2.0):
+    - RxSwift (~> 2.2)
+  - RxSwift (2.2.0)
 
 DEPENDENCIES:
   - Action (from `../`)
   - Nimble
   - Quick
-  - RxBlocking (~> 2.1)
-  - RxCocoa (~> 2.1)
-  - RxSwift (~> 2.1)
+  - RxBlocking (~> 2.2)
+  - RxCocoa (~> 2.2)
+  - RxSwift (~> 2.2)
 
 EXTERNAL SOURCES:
   Action:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  Action: d313d68136ecaa8c8419fcb59d87bd26f2f80522
+  Action: ca2687d883c05d49740c148a383fbcd51b4c71ba
   Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
   Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
-  RxBlocking: fa297def258d85c5beae9ed507f94645260b3747
-  RxCocoa: 79b5feb8378545336e756a0a33fcf5e95050b71c
-  RxSwift: 110fb07f81c17c2c3b3254d168363057b1880d18
+  RxBlocking: 5bbc826774c4290effa8fe070841e9d45e864639
+  RxCocoa: 42efb7a7145a8d1d5878e94ce48a580d29e0c796
+  RxSwift: b8a749f2204c6c7a5c29b306a9c3bc11d5b87c5b
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
Ran tests and this all works fine. Just bumped the RxSwift version to 2.2.0 as I couldn't use the Cocoapod in my new project. I haven't updated a cocoapod before so not entirely sure I've done this right but I tried to copy your 1.2.0 update as a template.