### PR TITLE
Added executionObservables to provide a mechanism for observing work

### DIFF
--- a/Action.swift
+++ b/Action.swift
@@ -4,7 +4,6 @@ import RxCocoa
 
 /// Typealias for compatibility with UIButton's rx_action property.
 public typealias CocoaAction = Action<Void, Void>
-public typealias CocoaActionExecuting = Action<Void, Observable<AnyObject?>>
 
 /// Possible errors from invoking execute()
 public enum ActionError: ErrorType {
@@ -112,7 +111,7 @@ public extension Action {
             work.multicast(buffer).connect()
         }
         
-        self._executionObservables.onNext(work)
+        self._executionObservables.onNext(buffer)
         
         buffer.subscribe(onNext: { element in
                     self._elements.onNext(element)

--- a/Action.swift
+++ b/Action.swift
@@ -3,7 +3,8 @@ import RxSwift
 import RxCocoa
 
 /// Typealias for compatibility with UIButton's rx_action property.
-public typealias CocoaAction = Action<Void, AnyObject?>
+public typealias CocoaAction = Action<Void, Void>
+public typealias CocoaActionExecuting = Action<Void, Observable<AnyObject?>>
 
 /// Possible errors from invoking execute()
 public enum ActionError: ErrorType {

--- a/Demo/DemoTests/ActionTests.swift
+++ b/Demo/DemoTests/ActionTests.swift
@@ -184,6 +184,18 @@ class ActionTests: QuickSpec {
                 expect(receivedElements) == testItems
             }
         }
+        
+        describe("execution observables") {
+            it("returns a new observable from execute() which sends work", closure: {
+                let subject = testExecutionObservablesSubject()
+                
+                subject
+                    .execute()
+                    .subscribeNext({ (string) in
+                        expect(string) == TestElement
+                }).addDisposableTo(disposeBag)
+            })
+        }
 
         describe("one element") {
             itBehavesLike("sending elements") { () -> (NSDictionary) in
@@ -214,7 +226,7 @@ class ActionTests: QuickSpec {
         it("only subscribes to observable returned from work factory once") {
             var invocations = 0
             let subject = Action<Void, Void>(workFactory: { _ in
-                invocations++
+                invocations += 1
                 return .empty()
             })
 
@@ -345,6 +357,16 @@ func errorSubject() -> Action<Void, Void> {
 func emptySubject() -> Action<Void, Void> {
     return Action(workFactory: { input in
         return .empty()
+    })
+}
+
+func testExecutionObservablesSubject() -> Action<Void, String> {
+    return Action(workFactory: { input in
+        return Observable.create({ (observer) -> Disposable in
+            observer.onNext(TestElement)
+            observer.onCompleted()
+            return NopDisposable.instance
+        })
     })
 }
 


### PR DESCRIPTION
Take a look at this approach, changing `Action<Void, Void>` to `Action<Void, AnyObject?>` seems to still maintain compatibility with UIButton's rx_action, however I'm still fairly new to RxSwift and Swift itself so I may not have the complete picture.

I've tested this and it allows me to use a pattern very similar to what I had been using in RAC where RACCommand had executionSignals.

If it's not quite right perhaps it'll be a nudge in the right direction :blush: 