### PR TITLE
Send completed event for work elements

### DIFF
--- a/Action.swift
+++ b/Action.swift
@@ -25,7 +25,7 @@ public final class Action<Input, Element> {
     }
     private let _errors = PublishSubject<ActionError>()
 
-    /// Whether or not we're currently executing. 
+    /// Elements of work from invocation of execute().
     /// Delivered on whatever scheduler they were sent from.
     public var elements: Observable<Element> {
         return self._elements.asObservable()
@@ -109,7 +109,9 @@ public extension Action {
                 onError: {[weak self] error in
                     self?._errors.onNext(ActionError.UnderlyingError(error))
                 },
-                onCompleted: nil,
+                onCompleted: {[weak self] in
+                    self?._elements.onCompleted()
+                },
                 onDisposed: {[weak self] in
                     self?.doLocked { self?._executing.value = false }
                 })


### PR DESCRIPTION
I would like to observe the events from invocation of `execute()` from the available public interface, and it seems `elements` observable is what I can use for this. But, I'm confused as to why the `onCompleted` is set to nil. Because of this, I added the `onCompleted` closure. 

Also, I'm a little confused with the documentation of `elements`, because it seem that would imply a `true` or `false` meaning. Let me know if my changes are good enough.
