### PR TITLE
New Rx style

### DIFF
--- a/Action+Internal.swift
+++ b/Action+Internal.swift
@@ -1,0 +1,37 @@
+import Foundation
+import RxSwift
+
+internal struct AssociatedKeys {
+    static var Action = "rx_action"
+    static var DisposeBag = "rx_disposeBag"
+}
+
+// Note: Actions performed in this extension are _not_ locked
+// So be careful!
+internal extension NSObject {
+
+    // A dispose bag to be used exclusively for the instance's rx_action.
+    internal var actionDisposeBag: DisposeBag {
+        var disposeBag: DisposeBag
+
+        if let lookup = objc_getAssociatedObject(self, &AssociatedKeys.DisposeBag) as? DisposeBag {
+            disposeBag = lookup
+        } else {
+            disposeBag = DisposeBag()
+            objc_setAssociatedObject(self, &AssociatedKeys.DisposeBag, disposeBag, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+
+        return disposeBag
+    }
+
+    // Resets the actionDisposeBag to nil, disposeing of any subscriptions within it.
+    internal func resetActionDisposeBag() {
+        objc_setAssociatedObject(self, &AssociatedKeys.DisposeBag, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    // Uses objc_sync on self to perform a locked operation.
+    internal func doLocked(_ closure: () -> Void) {
+        objc_sync_enter(self); defer { objc_sync_exit(self) }
+        closure()
+    }
+}

--- a/Action.swift
+++ b/Action.swift
@@ -165,6 +165,11 @@ private extension Action {
     }
 }
 
+fileprivate let executingQueue = DispatchQueue(label: "com.ashfurrow.Action.executingQueue", attributes: [])
+internal func doLocked(_ closure: () -> Void) {
+    executingQueue.sync(execute: closure)
+}
+
 internal extension BehaviorSubject where Element: ExpressibleByBooleanLiteral {
     var valueOrFalse: Element {
         guard let value = try? value() else { return false }

--- a/Action.xcodeproj/project.pbxproj
+++ b/Action.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5EBBAA181DB0E28800D7F400 /* Action+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBBAA171DB0E28800D7F400 /* Action+Internal.swift */; };
 		7F53BBE71D7F0BBA0098EC20 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F53BBE31D7F0BBA0098EC20 /* ActionTests.swift */; };
 		7F53BBE81D7F0BBA0098EC20 /* AlertActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F53BBE41D7F0BBA0098EC20 /* AlertActionTests.swift */; };
 		7F53BBE91D7F0BBA0098EC20 /* BarButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F53BBE51D7F0BBA0098EC20 /* BarButtonTests.swift */; };
@@ -72,6 +73,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5EBBAA171DB0E28800D7F400 /* Action+Internal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Action+Internal.swift"; sourceTree = SOURCE_ROOT; };
 		7F53BBE11D7F0B140098EC20 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7F53BBE31D7F0BBA0098EC20 /* ActionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionTests.swift; sourceTree = "<group>"; };
 		7F53BBE41D7F0BBA0098EC20 /* AlertActionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertActionTests.swift; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				BE73AD331CDCEAE0006F8B98 /* Action.swift */,
+				5EBBAA171DB0E28800D7F400 /* Action+Internal.swift */,
 				BE73AD341CDCEAE0006F8B98 /* AlertAction.swift */,
 				BE73AD351CDCEAE0006F8B98 /* UIBarButtonItem+Action.swift */,
 				BE73AD361CDCEAE0006F8B98 /* UIButton+Rx.swift */,
@@ -385,6 +388,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE73AD381CDCEAE0006F8B98 /* AlertAction.swift in Sources */,
+				5EBBAA181DB0E28800D7F400 /* Action+Internal.swift in Sources */,
 				BE73AD391CDCEAE0006F8B98 /* UIBarButtonItem+Action.swift in Sources */,
 				BE73AD371CDCEAE0006F8B98 /* Action.swift in Sources */,
 				BE73AD3A1CDCEAE0006F8B98 /* UIButton+Rx.swift in Sources */,

--- a/Action.xcodeproj/project.pbxproj
+++ b/Action.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3D37A3961DB4A97C0028BC0E /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D9C98331DB4A87B004A9F7C /* RxTest.framework */; };
 		5EBBAA181DB0E28800D7F400 /* Action+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBBAA171DB0E28800D7F400 /* Action+Internal.swift */; };
 		7F53BBE71D7F0BBA0098EC20 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F53BBE31D7F0BBA0098EC20 /* ActionTests.swift */; };
 		7F53BBE81D7F0BBA0098EC20 /* AlertActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F53BBE41D7F0BBA0098EC20 /* AlertActionTests.swift */; };
@@ -18,13 +19,11 @@
 		7F612AB01D7F106900B93BC5 /* RxBlocking.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7F612AAD1D7F106900B93BC5 /* RxBlocking.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7F612ABA1D7F10C000B93BC5 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7F612AB91D7F10C000B93BC5 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7F612ABC1D7F10C900B93BC5 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7F612ABB1D7F10C900B93BC5 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		7F612ABE1D7F10FE00B93BC5 /* RxTests.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7F612ABD1D7F10FE00B93BC5 /* RxTests.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7F612ABF1D7F110800B93BC5 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F612ABB1D7F10C900B93BC5 /* Nimble.framework */; };
 		7F612AC01D7F110800B93BC5 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F612AB91D7F10C000B93BC5 /* Quick.framework */; };
 		7F612AC11D7F110800B93BC5 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F612AAB1D7F106900B93BC5 /* RxSwift.framework */; };
 		7F612AC21D7F110800B93BC5 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F612AAC1D7F106900B93BC5 /* RxCocoa.framework */; };
 		7F612AC31D7F110800B93BC5 /* RxBlocking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F612AAD1D7F106900B93BC5 /* RxBlocking.framework */; };
-		7F612AC41D7F110800B93BC5 /* RxTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F612ABD1D7F10FE00B93BC5 /* RxTests.framework */; };
 		7F612AC51D7F110E00B93BC5 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F612AAB1D7F106900B93BC5 /* RxSwift.framework */; };
 		7F612AC61D7F110E00B93BC5 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F612AAC1D7F106900B93BC5 /* RxCocoa.framework */; };
 		7F612AC71D7F110E00B93BC5 /* RxBlocking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F612AAD1D7F106900B93BC5 /* RxBlocking.framework */; };
@@ -64,7 +63,6 @@
 				7F612AAE1D7F106900B93BC5 /* RxSwift.framework in CopyFiles */,
 				7F612AAF1D7F106900B93BC5 /* RxCocoa.framework in CopyFiles */,
 				7F612AB01D7F106900B93BC5 /* RxBlocking.framework in CopyFiles */,
-				7F612ABE1D7F10FE00B93BC5 /* RxTests.framework in CopyFiles */,
 				7F612ABA1D7F10C000B93BC5 /* Quick.framework in CopyFiles */,
 				7F612ABC1D7F10C900B93BC5 /* Nimble.framework in CopyFiles */,
 			);
@@ -73,6 +71,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3D9C98331DB4A87B004A9F7C /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Checkouts/RxSwift/build/Debug/RxTest.framework; sourceTree = "<group>"; };
 		5EBBAA171DB0E28800D7F400 /* Action+Internal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Action+Internal.swift"; sourceTree = SOURCE_ROOT; };
 		7F53BBE11D7F0B140098EC20 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7F53BBE31D7F0BBA0098EC20 /* ActionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionTests.swift; sourceTree = "<group>"; };
@@ -85,7 +84,6 @@
 		7F612AAD1D7F106900B93BC5 /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F612AB91D7F10C000B93BC5 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F612ABB1D7F10C900B93BC5 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7F612ABD1D7F10FE00B93BC5 /* RxTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RxTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F612ACC1D7F13B800B93BC5 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F612ACE1D7F13B800B93BC5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7F612AD01D7F13B800B93BC5 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -113,7 +111,7 @@
 				7F612AC11D7F110800B93BC5 /* RxSwift.framework in Frameworks */,
 				7F612AC21D7F110800B93BC5 /* RxCocoa.framework in Frameworks */,
 				7F612AC31D7F110800B93BC5 /* RxBlocking.framework in Frameworks */,
-				7F612AC41D7F110800B93BC5 /* RxTests.framework in Frameworks */,
+				3D37A3961DB4A97C0028BC0E /* RxTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -156,12 +154,12 @@
 		7F5E6A5C1D7F06C4000B6076 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3D9C98331DB4A87B004A9F7C /* RxTest.framework */,
 				7F612ABB1D7F10C900B93BC5 /* Nimble.framework */,
 				7F612AB91D7F10C000B93BC5 /* Quick.framework */,
 				7F612AAB1D7F106900B93BC5 /* RxSwift.framework */,
 				7F612AAC1D7F106900B93BC5 /* RxCocoa.framework */,
 				7F612AAD1D7F106900B93BC5 /* RxBlocking.framework */,
-				7F612ABD1D7F10FE00B93BC5 /* RxTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -431,7 +429,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Checkouts/RxSwift/build/Debug",
+				);
 				INFOPLIST_FILE = Tests/Action/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "-.Tests";
@@ -447,7 +448,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Checkouts/RxSwift/build/Debug",
+				);
 				INFOPLIST_FILE = Tests/Action/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "-.Tests";

--- a/Action.xcworkspace/xcshareddata/Action.xcscmblueprint
+++ b/Action.xcworkspace/xcshareddata/Action.xcscmblueprint
@@ -11,7 +11,7 @@
   },
   "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "26078A82-DCD2-4B72-8C8E-CBFF0FFF9C36",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
-    "95438028B10BBB846574013D29F154A00556A9D1" : "Action\/Carthage\/Checkouts\/Quick\/Externals\/Nimble\/",
+    "95438028B10BBB846574013D29F154A00556A9D1" : "Action\/Carthage\/Checkouts\/Nimble\/",
     "8B123162C394A0A0A138779108E4C59DD771865A" : "Action\/Carthage\/Checkouts\/RxSwift\/",
     "D0725CAC6FF2D66F2C83C2C48DC12106D42DAA64" : "Action\/Carthage\/Checkouts\/Quick\/",
     "EE83DA14852173089C59631969EDB7A9A8713EC2" : "Action\/"

--- a/AlertAction.swift
+++ b/AlertAction.swift
@@ -44,27 +44,25 @@ public extension Reactive where Base: UIAlertAction {
             }
         }
     }
-}
-
-extension UIAlertAction {
-    var rx_enabled: AnyObserver<Bool> {
-        return AnyObserver { [weak self] event in
-            MainScheduler.ensureExecutingOnScheduler()
-
-            switch event {
-            case .next(let value):
-                self?.isEnabled = value
-            case .error(let error):
-                let error = "Binding error to UI: \(error)"
-                #if DEBUG
-                    rxFatalError(error)
-                #else
-                    print(error)
-                #endif
-                break
-            case .completed:
-                break
-            }
-        }
-    }
+	
+	public var enabled: AnyObserver<Bool> {
+		return AnyObserver { [weak base] event in
+			MainScheduler.ensureExecutingOnScheduler()
+			
+			switch event {
+			case .next(let value):
+				base?.isEnabled = value
+			case .error(let error):
+				let error = "Binding error to UI: \(error)"
+				#if DEBUG
+					rxFatalError(error)
+				#else
+					print(error)
+				#endif
+				break
+			case .completed:
+				break
+			}
+		}
+	}
 }

--- a/AlertAction.swift
+++ b/AlertAction.swift
@@ -6,18 +6,22 @@ public extension UIAlertAction {
 
     public static func Action(_ title: String?, style: UIAlertActionStyle) -> UIAlertAction {
         return UIAlertAction(title: title, style: style, handler: { action in
-            action.rx_action?.execute()
+            action.rx.action?.execute()
+            return
         })
     }
+}
+
+public extension Reactive where Base: UIAlertAction {
 
     /// Binds enabled state of action to button, and subscribes to rx_tap to execute action.
     /// These subscriptions are managed in a private, inaccessible dispose bag. To cancel
     /// them, set the rx_action to nil or another action.
-    public var rx_action: CocoaAction? {
+    public var action: CocoaAction? {
         get {
             var action: CocoaAction?
             doLocked {
-                action = objc_getAssociatedObject(self, &AssociatedKeys.Action) as? Action
+                action = objc_getAssociatedObject(base, &AssociatedKeys.Action) as? Action
             }
             return action
         }
@@ -25,17 +29,17 @@ public extension UIAlertAction {
         set {
             doLocked {
                 // Store new value.
-                objc_setAssociatedObject(self, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+                objc_setAssociatedObject(base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
                 // This effectively disposes of any existing subscriptions.
-                self.resetActionDisposeBag()
+                self.base.resetActionDisposeBag()
 
                 // Set up new bindings, if applicable.
                 if let action = newValue {
                     action
                         .enabled
-                        .bindTo(self.rx_enabled)
-                        .addDisposableTo(self.actionDisposeBag)
+                        .bindTo(self.enabled)
+                        .addDisposableTo(self.base.actionDisposeBag)
                 }
             }
         }

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "3.0.0-beta.2"
+github "ReactiveX/RxSwift" "3.0.0-rc.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v5.0.0"
 github "Quick/Quick" "v0.10.0"
-github "ReactiveX/RxSwift" "3.0.0-beta.2"
+github "ReactiveX/RxSwift" "3.0.0-rc.1"

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -30,7 +30,7 @@ class ViewController: UIViewController {
 				// Demo: show an alert and complete the view's button action once the alert's OK button is pressed
 				let alertController = UIAlertController(title: "Hello world", message: "This alert was triggered by a button action", preferredStyle: .alert)
 				let ok = UIAlertAction.Action("OK", style: .default)
-				ok.rx_action = CocoaAction {
+				ok.rx.action = CocoaAction {
 					print("Alert's OK button was pressed")
 					observer.onCompleted()
 					return .empty()
@@ -41,10 +41,10 @@ class ViewController: UIViewController {
 				return Disposables.create()
             }
         }
-        button.rx_action = action
+        button.rx.action = action
 
         // Demo: add an action to a UIBarButtonItem in the navigation item
-        self.navigationItem.rightBarButtonItem!.rx_action = CocoaAction {
+        self.navigationItem.rightBarButtonItem!.rx.action = CocoaAction {
             print("Bar button item was pressed, simulating a 2 second action")
             return Observable.empty().delaySubscription(2, scheduler: MainScheduler.instance)
         }
@@ -52,8 +52,8 @@ class ViewController: UIViewController {
         // Demo: observe the output of both actions, spin an activity indicator
         // while performing the work
         Observable.combineLatest(
-            button.rx_action!.executing,
-            self.navigationItem.rightBarButtonItem!.rx_action!.executing) {
+            button.rx.action!.executing,
+            self.navigationItem.rightBarButtonItem!.rx.action!.executing) {
                 // we combine two boolean observable and output one boolean
                 a,b in
                 return a || b

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
 
 				// Demo: show an alert and complete the view's button action once the alert's OK button is pressed
 				let alertController = UIAlertController(title: "Hello world", message: "This alert was triggered by a button action", preferredStyle: .alert)
-				let ok = UIAlertAction.Action("OK", style: .default)
+				var ok = UIAlertAction.Action("OK", style: .default)
 				ok.rx.action = CocoaAction {
 					print("Alert's OK button was pressed")
 					observer.onCompleted()

--- a/Tests/Action/AlertActionTests.swift
+++ b/Tests/Action/AlertActionTests.swift
@@ -12,7 +12,7 @@ class AlertActionTests: QuickSpec {
         }
 
         it("respects setter") {
-            let subject = UIAlertAction.Action("Hi", style: .default)
+            var subject = UIAlertAction.Action("Hi", style: .default)
 
             let action = emptyAction()
 
@@ -22,7 +22,7 @@ class AlertActionTests: QuickSpec {
         }
 
         it("disables the alert action while executing") {
-            let subject = UIAlertAction.Action("Hi", style: .default)
+            var subject = UIAlertAction.Action("Hi", style: .default)
 
             var observer: AnyObserver<Void>!
             let action = CocoaAction(workFactory: { _ in
@@ -42,7 +42,7 @@ class AlertActionTests: QuickSpec {
         }
 
         it("disables the alert action if the Action is disabled") {
-            let subject = UIAlertAction.Action("Hi", style: .default)
+            var subject = UIAlertAction.Action("Hi", style: .default)
             let disposeBag = DisposeBag()
 
             subject.rx.action = emptyAction(.just(false))
@@ -59,7 +59,7 @@ class AlertActionTests: QuickSpec {
         }
         
         it("disposes of old action subscriptions when re-set") {
-            let subject = UIAlertAction.Action("Hi", style: .default)
+            var subject = UIAlertAction.Action("Hi", style: .default)
             
             var disposed = false
             autoreleasepool {

--- a/Tests/Action/AlertActionTests.swift
+++ b/Tests/Action/AlertActionTests.swift
@@ -8,7 +8,7 @@ class AlertActionTests: QuickSpec {
     override func spec() {
         it("is nil by default") {
             let subject = UIAlertAction.Action("Hi", style: .default)
-            expect(subject.rx_action).to( beNil() )
+            expect(subject.rx.action).to( beNil() )
         }
 
         it("respects setter") {
@@ -16,9 +16,9 @@ class AlertActionTests: QuickSpec {
 
             let action = emptyAction()
 
-            subject.rx_action = action
+            subject.rx.action = action
 
-            expect(subject.rx_action) === action
+            expect(subject.rx.action) === action
         }
 
         it("disables the alert action while executing") {
@@ -32,7 +32,7 @@ class AlertActionTests: QuickSpec {
                 }
             })
 
-            subject.rx_action = action
+            subject.rx.action = action
 
             action.execute()
             expect(subject.isEnabled).toEventually( beFalse() )
@@ -45,7 +45,7 @@ class AlertActionTests: QuickSpec {
             let subject = UIAlertAction.Action("Hi", style: .default)
             let disposeBag = DisposeBag()
 
-            subject.rx_action = emptyAction(.just(false))
+            subject.rx.action = emptyAction(.just(false))
             waitUntil { done in
                 subject.rx.observe(Bool.self, "enabled")
                     .take(1)
@@ -66,7 +66,7 @@ class AlertActionTests: QuickSpec {
                 let disposeBag = DisposeBag()
                 
                 let action = emptyAction()
-                subject.rx_action = action
+                subject.rx.action = action
                 
                 action
                     .elements
@@ -76,7 +76,7 @@ class AlertActionTests: QuickSpec {
                     .addDisposableTo(disposeBag)
             }
             
-            subject.rx_action = nil
+            subject.rx.action = nil
             
             expect(disposed) == true
         }

--- a/Tests/Action/BarButtonTests.swift
+++ b/Tests/Action/BarButtonTests.swift
@@ -9,7 +9,7 @@ class BarButtonTests: QuickSpec {
 		
 		it("is nil by default") {
 			let subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
-			expect(subject.rx_action).to( beNil() )
+			expect(subject.rx.action).to( beNil() )
 		}
 		
 		it("respects setter") {
@@ -17,9 +17,9 @@ class BarButtonTests: QuickSpec {
 			
 			let action = emptyAction()
 			
-			subject.rx_action = action
+			subject.rx.action = action
 			
-			expect(subject.rx_action) === action
+			expect(subject.rx.action) === action
 		}
 		
 		it("disables the button while executing") {
@@ -33,7 +33,7 @@ class BarButtonTests: QuickSpec {
 				}
 			})
 			
-			subject.rx_action = action
+			subject.rx.action = action
 			
 			action.execute()
 			expect(subject.isEnabled).toEventually( beFalse() )
@@ -45,7 +45,7 @@ class BarButtonTests: QuickSpec {
 		it("disables the button if the Action is disabled") {
 			let subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
 			
-			subject.rx_action = emptyAction(.just(false))
+			subject.rx.action = emptyAction(.just(false))
 			
 			expect(subject.isEnabled) == false
 		}
@@ -54,7 +54,7 @@ class BarButtonTests: QuickSpec {
 			let subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
 			
 			var executed = false
-			subject.rx_action = CocoaAction(enabledIf: .just(false), workFactory: { _ in
+			subject.rx.action = CocoaAction(enabledIf: .just(false), workFactory: { _ in
 				executed = true
 				return .empty()
 			})
@@ -72,7 +72,7 @@ class BarButtonTests: QuickSpec {
 				executed = true
 				return .empty()
 			})
-			subject.rx_action = action
+			subject.rx.action = action
 			
 			_ = subject.target?.perform(subject.action, with: subject)
 			
@@ -87,7 +87,7 @@ class BarButtonTests: QuickSpec {
 				let disposeBag = DisposeBag()
 				
 				let action = emptyAction()
-				subject.rx_action = action
+				subject.rx.action = action
 				
 				action
 					.elements
@@ -97,7 +97,7 @@ class BarButtonTests: QuickSpec {
 					.addDisposableTo(disposeBag)
 			}
 			
-			subject.rx_action = nil
+			subject.rx.action = nil
 			
 			expect(disposed) == true
 		}

--- a/Tests/Action/BarButtonTests.swift
+++ b/Tests/Action/BarButtonTests.swift
@@ -13,7 +13,7 @@ class BarButtonTests: QuickSpec {
 		}
 		
 		it("respects setter") {
-			let subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
+			var subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
 			
 			let action = emptyAction()
 			
@@ -23,7 +23,7 @@ class BarButtonTests: QuickSpec {
 		}
 		
 		it("disables the button while executing") {
-			let subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
+			var subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
 			
 			var observer: AnyObserver<Void>!
 			let action = CocoaAction(workFactory: { _ in
@@ -43,7 +43,7 @@ class BarButtonTests: QuickSpec {
 		}
 		
 		it("disables the button if the Action is disabled") {
-			let subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
+			var subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
 			
 			subject.rx.action = emptyAction(.just(false))
 			
@@ -51,7 +51,7 @@ class BarButtonTests: QuickSpec {
 		}
 		
 		it("doesn't execute a disabled action when tapped") {
-			let subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
+			var subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
 			
 			var executed = false
 			subject.rx.action = CocoaAction(enabledIf: .just(false), workFactory: { _ in
@@ -65,7 +65,7 @@ class BarButtonTests: QuickSpec {
 		}
 		
 		it("executes the action when tapped") {
-			let subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
+			var subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
 			
 			var executed = false
 			let action = CocoaAction(workFactory: { _ in
@@ -80,7 +80,7 @@ class BarButtonTests: QuickSpec {
 		}
 		
 		it("disposes of old action subscriptions when re-set") {
-			let subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
+			var subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
 			
 			var disposed = false
 			autoreleasepool {

--- a/Tests/Action/ButtonTests.swift
+++ b/Tests/Action/ButtonTests.swift
@@ -9,7 +9,7 @@ class ButtonTests: QuickSpec {
 
         it("is nil by default") {
             let subject = UIButton(type: .system)
-            expect(subject.rx_action).to( beNil() )
+            expect(subject.rx.action).to( beNil() )
         }
 
         it("respects setter") {
@@ -17,9 +17,9 @@ class ButtonTests: QuickSpec {
 
             let action = emptyAction()
 
-            subject.rx_action = action
+            subject.rx.action = action
 
-            expect(subject.rx_action) === action
+            expect(subject.rx.action) === action
         }
 
         it("disables the button while executing") {
@@ -33,7 +33,7 @@ class ButtonTests: QuickSpec {
                 }
             })
 
-            subject.rx_action = action
+            subject.rx.action = action
 
             action.execute()
             expect(subject.isEnabled).toEventually( beFalse() )
@@ -45,7 +45,7 @@ class ButtonTests: QuickSpec {
         it("disables the button if the Action is disabled") {
             let subject = UIButton(type: .system)
 
-            subject.rx_action = emptyAction(.just(false))
+            subject.rx.action = emptyAction(.just(false))
             
             expect(subject.isEnabled) == false
         }
@@ -54,7 +54,7 @@ class ButtonTests: QuickSpec {
             let subject = UIButton(type: .system)
 
             var executed = false
-            subject.rx_action = CocoaAction(enabledIf: .just(false), workFactory: { _ in
+            subject.rx.action = CocoaAction(enabledIf: .just(false), workFactory: { _ in
                 executed = true
                 return .empty()
             })
@@ -72,7 +72,7 @@ class ButtonTests: QuickSpec {
                 executed = true
                 return .empty()
             })
-            subject.rx_action = action
+            subject.rx.action = action
 
             // Normally I'd use subject.sendActionsForControlEvents(.TouchUpInside) but it's not working
             for case let target as NSObject in subject.allTargets {
@@ -92,7 +92,7 @@ class ButtonTests: QuickSpec {
                 let disposeBag = DisposeBag()
 
                 let action = emptyAction()
-                subject.rx_action = action
+                subject.rx.action = action
 
                 action
                     .elements
@@ -102,7 +102,7 @@ class ButtonTests: QuickSpec {
                     .addDisposableTo(disposeBag)
             }
 
-            subject.rx_action = nil
+            subject.rx.action = nil
 
             expect(disposed) == true
         }
@@ -121,8 +121,8 @@ class ButtonTests: QuickSpec {
                     }
                 }
                 
-                subject.rx_action = action
-                subject.rx_action?.execute()
+                subject.rx.action = action
+                subject.rx.action?.execute()
             }
             
             expect(disposed) == true

--- a/Tests/Action/ButtonTests.swift
+++ b/Tests/Action/ButtonTests.swift
@@ -13,7 +13,7 @@ class ButtonTests: QuickSpec {
         }
 
         it("respects setter") {
-            let subject = UIButton(type: .system)
+            var subject = UIButton(type: .system)
 
             let action = emptyAction()
 
@@ -23,7 +23,7 @@ class ButtonTests: QuickSpec {
         }
 
         it("disables the button while executing") {
-            let subject = UIButton(type: .system)
+            var subject = UIButton(type: .system)
 
             var observer: AnyObserver<Void>!
             let action = CocoaAction(workFactory: { _ in
@@ -43,7 +43,7 @@ class ButtonTests: QuickSpec {
         }
 
         it("disables the button if the Action is disabled") {
-            let subject = UIButton(type: .system)
+            var subject = UIButton(type: .system)
 
             subject.rx.action = emptyAction(.just(false))
             
@@ -51,7 +51,7 @@ class ButtonTests: QuickSpec {
         }
 
         it("doesn't execute a disabled action when tapped") {
-            let subject = UIButton(type: .system)
+            var subject = UIButton(type: .system)
 
             var executed = false
             subject.rx.action = CocoaAction(enabledIf: .just(false), workFactory: { _ in
@@ -65,7 +65,7 @@ class ButtonTests: QuickSpec {
         }
 
         it("executes the action when tapped") {
-            let subject = UIButton(type: .system)
+            var subject = UIButton(type: .system)
 
             var executed = false
             let action = CocoaAction(workFactory: { _ in
@@ -85,7 +85,7 @@ class ButtonTests: QuickSpec {
         }
 
         it("disposes of old action subscriptions when re-set") {
-            let subject = UIButton(type: .system)
+            var subject = UIButton(type: .system)
 
             var disposed = false
             autoreleasepool {
@@ -112,7 +112,7 @@ class ButtonTests: QuickSpec {
             var disposed = false
             
             autoreleasepool {
-                let subject = UIButton(type: .system)
+                var subject = UIButton(type: .system)
                 let action = CocoaAction {
                     return Observable.create {_ in
                         Disposables.create {

--- a/UIBarButtonItem+Action.swift
+++ b/UIBarButtonItem+Action.swift
@@ -12,7 +12,7 @@ public extension Reactive where Base: UIBarButtonItem {
         get {
             var action: CocoaAction?
             doLocked {
-                action = objc_getAssociatedObject(self, &AssociatedKeys.Action) as? Action
+                action = objc_getAssociatedObject(self.base, &AssociatedKeys.Action) as? Action
             }
             return action
         }
@@ -20,7 +20,7 @@ public extension Reactive where Base: UIBarButtonItem {
         set {
             doLocked {
                 // Store new value.
-                objc_setAssociatedObject(self, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+                objc_setAssociatedObject(self.base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
                 // This effectively disposes of any existing subscriptions.
                 self.base.resetActionDisposeBag()

--- a/UIBarButtonItem+Action.swift
+++ b/UIBarButtonItem+Action.swift
@@ -3,12 +3,12 @@ import RxSwift
 import RxCocoa
 import ObjectiveC
 
-public extension UIBarButtonItem {
+public extension Reactive where Base: UIBarButtonItem {
 
     /// Binds enabled state of action to bar button item, and subscribes to rx_tap to execute action.
     /// These subscriptions are managed in a private, inaccessible dispose bag. To cancel
     /// them, set the rx_action to nil or another action.
-    public var rx_action: CocoaAction? {
+    public var action: CocoaAction? {
         get {
             var action: CocoaAction?
             doLocked {
@@ -23,19 +23,19 @@ public extension UIBarButtonItem {
                 objc_setAssociatedObject(self, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
                 // This effectively disposes of any existing subscriptions.
-                self.resetActionDisposeBag()
+                self.base.resetActionDisposeBag()
 
                 // Set up new bindings, if applicable.
                 if let action = newValue {
                     action
                         .enabled
-                        .bindTo(self.rx.enabled)
-                        .addDisposableTo(self.actionDisposeBag)
+                        .bindTo(self.enabled)
+                        .addDisposableTo(self.base.actionDisposeBag)
 
-                    self.rx.tap.subscribe(onNext: { (_) in
+                    self.tap.subscribe(onNext: { (_) in
                         action.execute()
                     })
-                    .addDisposableTo(self.actionDisposeBag)
+                    .addDisposableTo(self.base.actionDisposeBag)
                 }
             }
         }

--- a/UIButton+Rx.swift
+++ b/UIButton+Rx.swift
@@ -11,7 +11,7 @@ public extension Reactive where Base: UIButton {
         get {
             var action: CocoaAction?
             doLocked {
-                action = objc_getAssociatedObject(self, &AssociatedKeys.Action) as? Action
+                action = objc_getAssociatedObject(self.base, &AssociatedKeys.Action) as? Action
             }
             return action
         }
@@ -19,7 +19,7 @@ public extension Reactive where Base: UIButton {
         set {
             doLocked {
                 // Store new value.
-                objc_setAssociatedObject(self, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+                objc_setAssociatedObject(self.base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
                 // This effectively disposes of any existing subscriptions.
                 self.base.resetActionDisposeBag()

--- a/UIButton+Rx.swift
+++ b/UIButton+Rx.swift
@@ -3,12 +3,11 @@ import RxSwift
 import RxCocoa
 import ObjectiveC
 
-public extension UIButton {
-
+public extension Reactive where Base: UIButton {
     /// Binds enabled state of action to button, and subscribes to rx_tap to execute action.
     /// These subscriptions are managed in a private, inaccessible dispose bag. To cancel
     /// them, set the rx_action to nil or another action.
-    public var rx_action: CocoaAction? {
+    public var action: CocoaAction? {
         get {
             var action: CocoaAction?
             doLocked {
@@ -23,23 +22,23 @@ public extension UIButton {
                 objc_setAssociatedObject(self, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
                 // This effectively disposes of any existing subscriptions.
-                self.resetActionDisposeBag()
+                self.base.resetActionDisposeBag()
 
                 // Set up new bindings, if applicable.
                 if let action = newValue {
                     action
                         .enabled
-                        .bindTo(self.rx.enabled)
-                        .addDisposableTo(self.actionDisposeBag)
+                        .bindTo(self.enabled)
+                        .addDisposableTo(self.base.actionDisposeBag)
 
                     // Technically, this file is only included on tv/iOS platforms,
                     // so this optional will never be nil. But let's be safe 😉
                     let lookupControlEvent: ControlEvent<Void>?
 
                     #if os(tvOS)
-                        lookupControlEvent = self.rx_primaryAction
+                        lookupControlEvent = self.primaryAction
                     #elseif os(iOS)
-                        lookupControlEvent = self.rx.tap
+                        lookupControlEvent = self.tap
                     #endif
 
                     guard let controlEvent = lookupControlEvent else {
@@ -50,43 +49,9 @@ public extension UIButton {
                         .subscribe(onNext: {
                             action.execute()
                         })
-                        .addDisposableTo(self.actionDisposeBag)
+                        .addDisposableTo(self.base.actionDisposeBag)
                 }
             }
         }
-    }
-}
-
-// Note: Actions performed in this extension are _not_ locked
-// So be careful!
-internal extension NSObject {
-    internal struct AssociatedKeys {
-        static var Action = "rx_action"
-        static var DisposeBag = "rx_disposeBag"
-    }
-
-    // A dispose bag to be used exclusively for the instance's rx_action.
-    internal var actionDisposeBag: DisposeBag {
-        var disposeBag: DisposeBag
-
-        if let lookup = objc_getAssociatedObject(self, &AssociatedKeys.DisposeBag) as? DisposeBag {
-            disposeBag = lookup
-        } else {
-            disposeBag = DisposeBag()
-            objc_setAssociatedObject(self, &AssociatedKeys.DisposeBag, disposeBag, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-
-        return disposeBag
-    }
-
-    // Resets the actionDisposeBag to nil, disposeing of any subscriptions within it.
-    internal func resetActionDisposeBag() {
-        objc_setAssociatedObject(self, &AssociatedKeys.DisposeBag, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-    }
-
-    // Uses objc_sync on self to perform a locked operation.
-    internal func doLocked(_ closure: () -> Void) {
-        objc_sync_enter(self); defer { objc_sync_exit(self) }
-        closure()
     }
 }


### PR DESCRIPTION
Changes `rx_action` to `rx.action`.

Fixes #50.

WIP because setting is currently borked. Consider:

```swift
button.rx.action = Action(...)
```

This produces an error `cannot assign to property 'rx' is get-only`. `rx` is a get-only property that is a struct value-type, which is causing the compiler to mix up. There's probably an easy way around this, I'm going to look through the RxSwift code to find it.