### PR TITLE
[WIP] Refactor internal implementation

### DIFF
--- a/Action.swift
+++ b/Action.swift
@@ -23,157 +23,109 @@ public final class Action<Input, Element> {
     /// All inputs are always appear in this subject even if the action is not enabled.
     /// Thus, inputs count equals elements count + errors count.
     public let inputs = PublishSubject<Input>()
-    fileprivate let _completed = PublishSubject<Void>()
 
-    /// Errors aggrevated from invocations of execute(). 
+    /// Errors aggrevated from invocations of execute().
     /// Delivered on whatever scheduler they were sent from.
-    public var errors: Observable<ActionError> {
-        return self._errors.asObservable()
-    }
-    fileprivate let _errors = PublishSubject<ActionError>()
+    public let errors: Observable<ActionError>
 
-    /// Whether or not we're currently executing. 
+    /// Whether or not we're currently executing.
     /// Delivered on whatever scheduler they were sent from.
-    public var elements: Observable<Element> {
-        return self._elements.asObservable()
-    }
-    fileprivate let _elements = PublishSubject<Element>()
+    public let elements: Observable<Element>
 
     /// Whether or not we're currently executing. 
     /// Always observed on MainScheduler.
-    public var executing: Observable<Bool> {
-        return self._executing.asObservable().observeOn(MainScheduler.instance)
-    }
-    fileprivate let _executing = Variable(false)
-    
+    public let executing: Observable<Bool>
+
     /// Observables returned by the workFactory.
     /// Useful for sending results back from work being completed
     /// e.g. response from a network call.
-    public var executionObservables: Observable<Observable<Element>> {
-        return self._executionObservables.asObservable().observeOn(MainScheduler.instance)
-    }
-    fileprivate let _executionObservables = PublishSubject<Observable<Element>>()
-    
+    public let executionObservables: Observable<Observable<Element>>
+
     /// Whether or not we're enabled. Note that this is a *computed* sequence
     /// property based on enabledIf initializer and if we're currently executing.
     /// Always observed on MainScheduler.
-    public var enabled: Observable<Bool> {
-        return _enabled.asObservable().observeOn(MainScheduler.instance)
-    }
-    public fileprivate(set) var _enabled = BehaviorSubject(value: true)
+    public let enabled: Observable<Bool>
 
-    fileprivate let executingQueue = DispatchQueue(label: "com.ashfurrow.Action.executingQueue", attributes: [])
-    fileprivate let disposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
 
-    public init(enabledIf: Observable<Bool> = Observable.just(true), workFactory: @escaping WorkFactory) {
-        self._enabledIf = enabledIf
+    public init(
+        enabledIf: Observable<Bool> = Observable.just(true),
+        workFactory: @escaping WorkFactory) {
         
+        self._enabledIf = enabledIf
         self.workFactory = workFactory
 
-        Observable.combineLatest(self._enabledIf, self.executing) { (enabled, executing) -> Bool in
-            return enabled && !executing
-        }.bindTo(_enabled).addDisposableTo(disposeBag)
-
-        self.inputs.subscribe(onNext: { [weak self] (input) in
-            self?._execute(input)
-        }).addDisposableTo(disposeBag)
-    }
-}
-
-
-// MARK: Execution!
-public extension Action {
-
-    @discardableResult
-    public func execute(_ input: Input) -> Observable<Element> {
-        let buffer = ReplaySubject<Element>.createUnbounded()
-        let error = errors
-            .flatMap { error -> Observable<Element> in
-                if case .underlyingError(let error) = error {
-                    throw error
+        let enabledSubject = BehaviorSubject<Bool>(value: false)
+        enabled = enabledSubject.asObservable()
+        
+        executionObservables = inputs
+            .withLatestFrom(enabledSubject) { input, enabled in
+                if enabled {
+                    return input
                 } else {
-                    return Observable.empty()
+                    throw ActionError.notEnabled
                 }
             }
-        
-        Observable
-            .of(elements, error)
+            .flatMap { Observable.of(workFactory($0).shareReplay(1)) }
+            .shareReplay(1)
+
+        elements = executionObservables
+            .catchError { _ in Observable.empty() }
+            .flatMap { $0.catchError { _ in Observable.empty() } }
+            
+        errors = executionObservables
+            .flatMap { elements in
+                return elements
+                    .flatMap { _ in Observable<ActionError>.never() }
+                    .catchError { error in
+                        if let actionError = error as? ActionError {
+                            return Observable.of(actionError)
+                        } else {
+                            return Observable.of(.underlyingError(error))
+                        }
+                    }
+            }
+            .catchError { error in
+                if let actionError = error as? ActionError {
+                    return Observable.of(actionError)
+                } else {
+                    return Observable.of(.underlyingError(error))
+                }
+            }
+
+        let executionStart = executionObservables.catchError { _ in Observable.empty() }
+        let executionEnd = executionObservables
+            .catchError { _ in Observable.empty() }
+            .flatMap { observable -> Observable<Void> in
+                return observable
+                    .flatMap { _ in Observable<Void>.empty() }
+                    .concat(Observable.just())
+                    .catchErrorJustReturn()
+            }
+
+        executing = Observable
+            .of(executionStart.map { _ in true }, executionEnd.map { _ in false })
             .merge()
-            .takeUntil(_completed)
-            .bindTo(buffer)
+            .startWith(false)
+
+        Observable
+            .combineLatest(executing, enabledIf) { !$0 && $1 }
+            .bindTo(enabledSubject)
             .addDisposableTo(disposeBag)
-        
-        inputs.onNext(input)
-        
-        return buffer.asObservable()
     }
 
     @discardableResult
-    fileprivate func _execute(_ input: Input) -> Observable<Element> {
+    public func execute(_ value: Input) -> Observable<Element> {
+        let subject = ReplaySubject<Element>.createUnbounded()
 
-        // Buffer from the work to a replay subject.
-        let buffer = ReplaySubject<Element>.createUnbounded()
-
-        // See if we're already executing.
-        var startedExecuting = false
-        self.doLocked {
-            if self._enabled.valueOrFalse {
-                self._executing.value = true
-                startedExecuting = true
-            }
-        }
-
-        // Make sure we started executing and we're accidentally disabled.
-        guard startedExecuting else {
-            let error = ActionError.notEnabled
-            self._errors.onNext(error)
-            buffer.onError(error)
-
-            return buffer
-        }
-
-        let work = self.workFactory(input)
-        defer {
-            // Subscribe to the work.
-            work.multicast(buffer).connect().addDisposableTo(disposeBag)
-        }
-
-		self._executionObservables.onNext(buffer)
-
-        buffer.subscribe(onNext: {[weak self] element in
-                    self?._elements.onNext(element)
-                },
-                onError: {[weak self] error in
-                    self?._errors.onNext(ActionError.underlyingError(error))
-                },
-                onCompleted: {[weak self] in
-                    self?._completed.onNext()
-                },
-                onDisposed: {[weak self] in
-                    self?.doLocked { self?._executing.value = false }
-                })
+        executionObservables
+            .take(1)
+            .flatMap { $0 }
+            .bindTo(subject)
             .addDisposableTo(disposeBag)
 
+        inputs.onNext(value)
 
-        return buffer.asObservable()
-    }
-}
-
-private extension Action {
-    func doLocked(_ closure: () -> Void) {
-        executingQueue.sync(execute: closure)
-    }
-}
-
-fileprivate let executingQueue = DispatchQueue(label: "com.ashfurrow.Action.executingQueue", attributes: [])
-internal func doLocked(_ closure: () -> Void) {
-    executingQueue.sync(execute: closure)
-}
-
-internal extension BehaviorSubject where Element: ExpressibleByBooleanLiteral {
-    var valueOrFalse: Element {
-        guard let value = try? value() else { return false }
-
-        return value
+        return subject.asObservable()
     }
 }

--- a/AlertAction.swift
+++ b/AlertAction.swift
@@ -20,27 +20,23 @@ public extension Reactive where Base: UIAlertAction {
     public var action: CocoaAction? {
         get {
             var action: CocoaAction?
-            doLocked {
-                action = objc_getAssociatedObject(base, &AssociatedKeys.Action) as? Action
-            }
+            action = objc_getAssociatedObject(base, &AssociatedKeys.Action) as? Action
             return action
         }
 
         set {
-            doLocked {
-                // Store new value.
-                objc_setAssociatedObject(base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-
-                // This effectively disposes of any existing subscriptions.
-                self.base.resetActionDisposeBag()
-
-                // Set up new bindings, if applicable.
-                if let action = newValue {
-                    action
-                        .enabled
-                        .bindTo(self.enabled)
-                        .addDisposableTo(self.base.actionDisposeBag)
-                }
+            // Store new value.
+            objc_setAssociatedObject(base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            
+            // This effectively disposes of any existing subscriptions.
+            self.base.resetActionDisposeBag()
+            
+            // Set up new bindings, if applicable.
+            if let action = newValue {
+                action
+                    .enabled
+                    .bindTo(self.enabled)
+                    .addDisposableTo(self.base.actionDisposeBag)
             }
         }
     }

--- a/UIBarButtonItem+Action.swift
+++ b/UIBarButtonItem+Action.swift
@@ -11,32 +11,28 @@ public extension Reactive where Base: UIBarButtonItem {
     public var action: CocoaAction? {
         get {
             var action: CocoaAction?
-            doLocked {
-                action = objc_getAssociatedObject(self.base, &AssociatedKeys.Action) as? Action
-            }
+            action = objc_getAssociatedObject(self.base, &AssociatedKeys.Action) as? Action
             return action
         }
 
         set {
-            doLocked {
-                // Store new value.
-                objc_setAssociatedObject(self.base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-
-                // This effectively disposes of any existing subscriptions.
-                self.base.resetActionDisposeBag()
-
-                // Set up new bindings, if applicable.
-                if let action = newValue {
-                    action
-                        .enabled
-                        .bindTo(self.isEnabled)
-                        .addDisposableTo(self.base.actionDisposeBag)
-
-                    self.tap.subscribe(onNext: { (_) in
-                        action.execute()
-                    })
+            // Store new value.
+            objc_setAssociatedObject(self.base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            
+            // This effectively disposes of any existing subscriptions.
+            self.base.resetActionDisposeBag()
+            
+            // Set up new bindings, if applicable.
+            if let action = newValue {
+                action
+                    .enabled
+                    .bindTo(self.isEnabled)
                     .addDisposableTo(self.base.actionDisposeBag)
-                }
+                
+                self.tap.subscribe(onNext: { (_) in
+                    action.execute()
+                })
+                    .addDisposableTo(self.base.actionDisposeBag)
             }
         }
     }

--- a/UIButton+Rx.swift
+++ b/UIButton+Rx.swift
@@ -10,47 +10,43 @@ public extension Reactive where Base: UIButton {
     public var action: CocoaAction? {
         get {
             var action: CocoaAction?
-            doLocked {
-                action = objc_getAssociatedObject(self.base, &AssociatedKeys.Action) as? Action
-            }
+            action = objc_getAssociatedObject(self.base, &AssociatedKeys.Action) as? Action
             return action
         }
 
         set {
-            doLocked {
-                // Store new value.
-                objc_setAssociatedObject(self.base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-
-                // This effectively disposes of any existing subscriptions.
-                self.base.resetActionDisposeBag()
-
-                // Set up new bindings, if applicable.
-                if let action = newValue {
-                    action
-                        .enabled
-                        .bindTo(self.isEnabled)
-                        .addDisposableTo(self.base.actionDisposeBag)
-
-                    // Technically, this file is only included on tv/iOS platforms,
-                    // so this optional will never be nil. But let's be safe 😉
-                    let lookupControlEvent: ControlEvent<Void>?
-
-                    #if os(tvOS)
-                        lookupControlEvent = self.primaryAction
-                    #elseif os(iOS)
-                        lookupControlEvent = self.tap
-                    #endif
-
-                    guard let controlEvent = lookupControlEvent else {
-                        return
-                    }
-
-                    controlEvent
-                        .subscribe(onNext: {
-                            action.execute()
-                        })
-                        .addDisposableTo(self.base.actionDisposeBag)
+            // Store new value.
+            objc_setAssociatedObject(self.base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            
+            // This effectively disposes of any existing subscriptions.
+            self.base.resetActionDisposeBag()
+            
+            // Set up new bindings, if applicable.
+            if let action = newValue {
+                action
+                    .enabled
+                    .bindTo(self.isEnabled)
+                    .addDisposableTo(self.base.actionDisposeBag)
+                
+                // Technically, this file is only included on tv/iOS platforms,
+                // so this optional will never be nil. But let's be safe 😉
+                let lookupControlEvent: ControlEvent<Void>?
+                
+                #if os(tvOS)
+                    lookupControlEvent = self.primaryAction
+                #elseif os(iOS)
+                    lookupControlEvent = self.tap
+                #endif
+                
+                guard let controlEvent = lookupControlEvent else {
+                    return
                 }
+                
+                controlEvent
+                    .subscribe(onNext: {
+                        action.execute()
+                    })
+                    .addDisposableTo(self.base.actionDisposeBag)
             }
         }
     }


### PR DESCRIPTION
This PR refactors internal implementation to focus more on observables, and public APIs and unit tests are not changed.

The changes minimize:

- Use of private subjects
- Stored properties that manage state
- Manual locking
