### PR TITLE
Refactor internal implementation and add more test cases

### DIFF
--- a/Action.swift
+++ b/Action.swift
@@ -93,9 +93,8 @@ public final class Action<Input, Element> {
             .of(notEnabledError, underlyingError)
             .merge()
 
-        let executionStart = executionObservables.catchError { _ in Observable.empty() }
+        let executionStart = executionObservables
         let executionEnd = executionObservables
-            .catchError { _ in Observable.empty() }
             .flatMap { observable -> Observable<Void> in
                 return observable
                     .flatMap { _ in Observable<Void>.empty() }

--- a/Action.swift
+++ b/Action.swift
@@ -23,157 +23,114 @@ public final class Action<Input, Element> {
     /// All inputs are always appear in this subject even if the action is not enabled.
     /// Thus, inputs count equals elements count + errors count.
     public let inputs = PublishSubject<Input>()
-    fileprivate let _completed = PublishSubject<Void>()
 
-    /// Errors aggrevated from invocations of execute(). 
+    /// Errors aggrevated from invocations of execute().
     /// Delivered on whatever scheduler they were sent from.
-    public var errors: Observable<ActionError> {
-        return self._errors.asObservable()
-    }
-    fileprivate let _errors = PublishSubject<ActionError>()
+    public let errors: Observable<ActionError>
 
-    /// Whether or not we're currently executing. 
+    /// Whether or not we're currently executing.
     /// Delivered on whatever scheduler they were sent from.
-    public var elements: Observable<Element> {
-        return self._elements.asObservable()
-    }
-    fileprivate let _elements = PublishSubject<Element>()
+    public let elements: Observable<Element>
 
     /// Whether or not we're currently executing. 
     /// Always observed on MainScheduler.
-    public var executing: Observable<Bool> {
-        return self._executing.asObservable().observeOn(MainScheduler.instance)
-    }
-    fileprivate let _executing = Variable(false)
-    
+    public let executing: Observable<Bool>
+
     /// Observables returned by the workFactory.
     /// Useful for sending results back from work being completed
     /// e.g. response from a network call.
-    public var executionObservables: Observable<Observable<Element>> {
-        return self._executionObservables.asObservable().observeOn(MainScheduler.instance)
-    }
-    fileprivate let _executionObservables = PublishSubject<Observable<Element>>()
-    
+    public let executionObservables: Observable<Observable<Element>>
+
     /// Whether or not we're enabled. Note that this is a *computed* sequence
     /// property based on enabledIf initializer and if we're currently executing.
     /// Always observed on MainScheduler.
-    public var enabled: Observable<Bool> {
-        return _enabled.asObservable().observeOn(MainScheduler.instance)
-    }
-    public fileprivate(set) var _enabled = BehaviorSubject(value: true)
+    public let enabled: Observable<Bool>
 
-    fileprivate let executingQueue = DispatchQueue(label: "com.ashfurrow.Action.executingQueue", attributes: [])
-    fileprivate let disposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
 
-    public init(enabledIf: Observable<Bool> = Observable.just(true), workFactory: @escaping WorkFactory) {
-        self._enabledIf = enabledIf
+    public init(
+        enabledIf: Observable<Bool> = Observable.just(true),
+        workFactory: @escaping WorkFactory) {
         
+        self._enabledIf = enabledIf
         self.workFactory = workFactory
 
-        Observable.combineLatest(self._enabledIf, self.executing) { (enabled, executing) -> Bool in
-            return enabled && !executing
-        }.bindTo(_enabled).addDisposableTo(disposeBag)
-
-        self.inputs.subscribe(onNext: { [weak self] (input) in
-            self?._execute(input)
-        }).addDisposableTo(disposeBag)
-    }
-}
-
-
-// MARK: Execution!
-public extension Action {
-
-    @discardableResult
-    public func execute(_ input: Input) -> Observable<Element> {
-        let buffer = ReplaySubject<Element>.createUnbounded()
-        let error = errors
-            .flatMap { error -> Observable<Element> in
-                if case .underlyingError(let error) = error {
-                    throw error
+        let enabledSubject = BehaviorSubject<Bool>(value: false)
+        enabled = enabledSubject.asObservable()
+        
+        executionObservables = inputs
+            .withLatestFrom(enabled) { $0 }
+            .flatMap { input, enabled -> Observable<Observable<Element>> in
+                if enabled {
+                    return Observable.of(workFactory(input).shareReplay(1))
                 } else {
                     return Observable.empty()
                 }
             }
+            .shareReplay(1)
+
+        elements = executionObservables
+            .flatMap { $0.catchError { _ in Observable.empty() } }
+
+        let notEnabledError = inputs
+            .withLatestFrom(enabled)
+            .flatMap { $0 ? Observable.empty() : Observable.of(ActionError.notEnabled) }
+
+        let underlyingError = executionObservables
+            .flatMap { elements in
+                return elements
+                    .flatMap { _ in Observable<ActionError>.never() }
+                    .catchError { error in
+                        if let actionError = error as? ActionError {
+                            return Observable.of(actionError)
+                        } else {
+                            return Observable.of(.underlyingError(error))
+                        }
+                    }
+            }
         
-        Observable
-            .of(elements, error)
+        errors = Observable
+            .of(notEnabledError, underlyingError)
             .merge()
-            .takeUntil(_completed)
-            .bindTo(buffer)
+
+        let executionStart = executionObservables.catchError { _ in Observable.empty() }
+        let executionEnd = executionObservables
+            .catchError { _ in Observable.empty() }
+            .flatMap { observable -> Observable<Void> in
+                return observable
+                    .flatMap { _ in Observable<Void>.empty() }
+                    .concat(Observable.just())
+                    .catchErrorJustReturn()
+            }
+
+        executing = Observable
+            .of(executionStart.map { _ in true }, executionEnd.map { _ in false })
+            .merge()
+            .startWith(false)
+
+        Observable
+            .combineLatest(executing, enabledIf) { !$0 && $1 }
+            .bindTo(enabledSubject)
             .addDisposableTo(disposeBag)
-        
-        inputs.onNext(input)
-        
-        return buffer.asObservable()
     }
 
     @discardableResult
-    fileprivate func _execute(_ input: Input) -> Observable<Element> {
+    public func execute(_ value: Input) -> Observable<Element> {
+        let subject = ReplaySubject<Element>.createUnbounded()
 
-        // Buffer from the work to a replay subject.
-        let buffer = ReplaySubject<Element>.createUnbounded()
-
-        // See if we're already executing.
-        var startedExecuting = false
-        self.doLocked {
-            if self._enabled.valueOrFalse {
-                self._executing.value = true
-                startedExecuting = true
-            }
-        }
-
-        // Make sure we started executing and we're accidentally disabled.
-        guard startedExecuting else {
-            let error = ActionError.notEnabled
-            self._errors.onNext(error)
-            buffer.onError(error)
-
-            return buffer
-        }
-
-        let work = self.workFactory(input)
-        defer {
-            // Subscribe to the work.
-            work.multicast(buffer).connect().addDisposableTo(disposeBag)
-        }
-
-		self._executionObservables.onNext(buffer)
-
-        buffer.subscribe(onNext: {[weak self] element in
-                    self?._elements.onNext(element)
-                },
-                onError: {[weak self] error in
-                    self?._errors.onNext(ActionError.underlyingError(error))
-                },
-                onCompleted: {[weak self] in
-                    self?._completed.onNext()
-                },
-                onDisposed: {[weak self] in
-                    self?.doLocked { self?._executing.value = false }
-                })
+        executionObservables
+            .take(1)
+            .flatMap { $0.catchError { _ in Observable.never() } }
+            .bindTo(subject)
             .addDisposableTo(disposeBag)
 
+        errors
+            .map { throw $0 }
+            .bindTo(subject)
+            .addDisposableTo(disposeBag)
 
-        return buffer.asObservable()
-    }
-}
+        inputs.onNext(value)
 
-private extension Action {
-    func doLocked(_ closure: () -> Void) {
-        executingQueue.sync(execute: closure)
-    }
-}
-
-fileprivate let executingQueue = DispatchQueue(label: "com.ashfurrow.Action.executingQueue", attributes: [])
-internal func doLocked(_ closure: () -> Void) {
-    executingQueue.sync(execute: closure)
-}
-
-internal extension BehaviorSubject where Element: ExpressibleByBooleanLiteral {
-    var valueOrFalse: Element {
-        guard let value = try? value() else { return false }
-
-        return value
+        return subject.asObservable()
     }
 }

--- a/AlertAction.swift
+++ b/AlertAction.swift
@@ -20,27 +20,23 @@ public extension Reactive where Base: UIAlertAction {
     public var action: CocoaAction? {
         get {
             var action: CocoaAction?
-            doLocked {
-                action = objc_getAssociatedObject(base, &AssociatedKeys.Action) as? Action
-            }
+            action = objc_getAssociatedObject(base, &AssociatedKeys.Action) as? Action
             return action
         }
 
         set {
-            doLocked {
-                // Store new value.
-                objc_setAssociatedObject(base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-
-                // This effectively disposes of any existing subscriptions.
-                self.base.resetActionDisposeBag()
-
-                // Set up new bindings, if applicable.
-                if let action = newValue {
-                    action
-                        .enabled
-                        .bindTo(self.enabled)
-                        .addDisposableTo(self.base.actionDisposeBag)
-                }
+            // Store new value.
+            objc_setAssociatedObject(base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            
+            // This effectively disposes of any existing subscriptions.
+            self.base.resetActionDisposeBag()
+            
+            // Set up new bindings, if applicable.
+            if let action = newValue {
+                action
+                    .enabled
+                    .bindTo(self.enabled)
+                    .addDisposableTo(self.base.actionDisposeBag)
             }
         }
     }

--- a/Tests/Action/ActionTests.swift
+++ b/Tests/Action/ActionTests.swift
@@ -2,14 +2,429 @@ import Quick
 import Nimble
 import RxSwift
 import RxBlocking
+import RxTest
 import Action
 
 class ActionTests: QuickSpec {
     override func spec() {
+        var scheduler: TestScheduler!
         var disposeBag: DisposeBag!
 
         beforeEach {
+            scheduler = TestScheduler(initialClock: 0)
             disposeBag = DisposeBag()
+        }
+
+        describe("action properties") {
+            var inputs: TestableObserver<String>!
+            var elements: TestableObserver<String>!
+            var errors: TestableObserver<ActionError>!
+            var enabled: TestableObserver<Bool>!
+            var executing: TestableObserver<Bool>!
+
+            beforeEach {
+                inputs = scheduler.createObserver(String.self)
+                elements = scheduler.createObserver(String.self)
+                errors = scheduler.createObserver(ActionError.self)
+                enabled = scheduler.createObserver(Bool.self)
+                executing = scheduler.createObserver(Bool.self)
+            }
+
+            func bindAction(action: Action<String, String>) {
+                action.inputs
+                    .bindTo(inputs)
+                    .addDisposableTo(disposeBag)
+
+                action.elements
+                    .bindTo(elements)
+                    .addDisposableTo(disposeBag)
+
+                action.errors
+                    .bindTo(errors)
+                    .addDisposableTo(disposeBag)
+                
+                action.enabled
+                    .bindTo(enabled)
+                    .addDisposableTo(disposeBag)
+                
+                action.executing
+                    .bindTo(executing)
+                    .addDisposableTo(disposeBag)
+            }
+
+            describe("single element action") {
+                sharedExamples("send elements to elements observable") {
+                    it("inputs subject receives generated inputs") {
+                        XCTAssertEqual(inputs.events, [
+                            next(10, "a"),
+                            next(20, "b"),
+                        ])
+                    }
+
+                    it("elements observable receives generated elements") {
+                        XCTAssertEqual(elements.events, [
+                            next(10, "a"),
+                            next(20, "b"),
+                        ])
+                    }
+                    
+                    it("errors observable receives nothing") {
+                        XCTAssertEqual(errors.events, [])
+                    }
+                    
+                    it("disabled until element returns") {
+                        XCTAssertEqual(enabled.events, [
+                            next(0, true),
+                            next(10, false),
+                            next(10, true),
+                            next(20, false),
+                            next(20, true),
+                        ])
+                    }
+                    
+                    it("executing until element returns") {
+                        XCTAssertEqual(executing.events, [
+                            next(0, false),
+                            next(10, true),
+                            next(10, false),
+                            next(20, true),
+                            next(20, false),
+                        ])
+                    }
+                }
+
+                var action: Action<String, String>!
+
+                beforeEach {
+                    action = Action { Observable.just($0) }
+                    bindAction(action: action)
+                }
+
+                context("trigger via inputs subject") {
+                    beforeEach {
+                        scheduler.scheduleAt(10) { action.inputs.onNext("a") }
+                        scheduler.scheduleAt(20) { action.inputs.onNext("b") }
+                        scheduler.start()
+                    }
+
+                    itBehavesLike("send elements to elements observable")
+                }
+
+                context("trigger via execute() method") {
+                    beforeEach {
+                        scheduler.scheduleAt(10) { action.execute("a") }
+                        scheduler.scheduleAt(20) { action.execute("b") }
+                        scheduler.start()
+                    }
+
+                    itBehavesLike("send elements to elements observable")
+                }
+            }
+
+            describe("multiple element action") {
+                sharedExamples("send array elements to elements observable") {
+                    it("inputs subject receives generated inputs") {
+                        XCTAssertEqual(inputs.events, [
+                            next(10, "a"),
+                            next(20, "b"),
+                        ])
+                    }
+
+                    it("elements observable receives generated elements") {
+                        XCTAssertEqual(elements.events, [
+                            next(10, "a"),
+                            next(10, "b"),
+                            next(10, "c"),
+                            next(20, "b"),
+                            next(20, "c"),
+                            next(20, "d"),
+                        ])
+                    }
+                    
+                    it("errors observable receives nothing") {
+                        XCTAssertEqual(errors.events, [])
+                    }
+
+                    it("disabled until element returns") {
+                        XCTAssertEqual(enabled.events, [
+                            next(0, true),
+                            next(10, false),
+                            next(10, true),
+                            next(20, false),
+                            next(20, true),
+                        ])
+                    }
+                    
+                    it("executing until element returns") {
+                        XCTAssertEqual(executing.events, [
+                            next(0, false),
+                            next(10, true),
+                            next(10, false),
+                            next(20, true),
+                            next(20, false),
+                        ])
+                    }
+                }
+
+                var action: Action<String, String>!
+
+                beforeEach {
+                    action = Action { input in
+                        // "a" -> ["a", "b", "c"]
+                        let baseValue = UnicodeScalar(input)!.value
+                        let strings = (baseValue..<(baseValue + 3))
+                            .flatMap { UnicodeScalar($0) }
+                            .map { String($0) }
+
+                        return Observable.from(strings)
+                    }
+
+                    bindAction(action: action)
+                }
+
+                context("trigger via inputs subject") {
+                    beforeEach {
+                        scheduler.scheduleAt(10) { action.inputs.onNext("a") }
+                        scheduler.scheduleAt(20) { action.inputs.onNext("b") }
+                        scheduler.start()
+                    }
+
+                    itBehavesLike("send array elements to elements observable")
+                }
+
+                context("trigger via execute() method") {
+                    beforeEach {
+                        scheduler.scheduleAt(10) { action.execute("a") }
+                        scheduler.scheduleAt(20) { action.execute("b") }
+                        scheduler.start()
+                    }
+
+                    itBehavesLike("send array elements to elements observable")
+                }
+            }
+
+            describe("error action") {
+                sharedExamples("send errors to errors observable") {
+                    it("inputs subject receives generated inputs") {
+                        XCTAssertEqual(inputs.events, [
+                            next(10, "a"),
+                            next(20, "b"),
+                        ])
+                    }
+
+                    it("elements observable receives nothing") {
+                        XCTAssertEqual(elements.events, [])
+                    }
+                    
+                    it("errors observable receives generated errors") {
+                        XCTAssertEqual(errors.events, [
+                            next(10, .underlyingError(TestError)),
+                            next(20, .underlyingError(TestError)),
+                        ])
+                    }
+
+                    it("disabled until error returns") {
+                        XCTAssertEqual(enabled.events, [
+                            next(0, true),
+                            next(10, false),
+                            next(10, true),
+                            next(20, false),
+                            next(20, true),
+                        ])
+                    }
+                    
+                    it("executing until error returns") {
+                        XCTAssertEqual(executing.events, [
+                            next(0, false),
+                            next(10, true),
+                            next(10, false),
+                            next(20, true),
+                            next(20, false),
+                        ])
+                    }
+                }
+
+                var action: Action<String, String>!
+
+                beforeEach {
+                    action = Action { _ in Observable.error(TestError) }
+                    bindAction(action: action)
+                }
+
+                context("trigger via inputs subject") {
+                    beforeEach {
+                        scheduler.scheduleAt(10) { action.inputs.onNext("a") }
+                        scheduler.scheduleAt(20) { action.inputs.onNext("b") }
+                        scheduler.start()
+                    }
+
+                    itBehavesLike("send errors to errors observable")
+                }
+
+                context("trigger via execute() method") {
+                    beforeEach {
+                        scheduler.scheduleAt(10) { action.execute("a") }
+                        scheduler.scheduleAt(20) { action.execute("b") }
+                        scheduler.start()
+                    }
+
+                    itBehavesLike("send errors to errors observable")
+                }
+            }
+
+            describe("disabled action") {
+                sharedExamples("send notEnabled errors to errors observable") {
+                    it("inputs subject receives generated inputs") {
+                        XCTAssertEqual(inputs.events, [
+                            next(10, "a"),
+                            next(20, "b"),
+                        ])
+                    }
+
+                    it("elements observable receives nothing") {
+                        XCTAssertEqual(elements.events, [])
+                    }
+                    
+                    it("errors observable receives generated errors") {
+                        XCTAssertEqual(errors.events, [
+                            next(10, .notEnabled),
+                            next(20, .notEnabled),
+                        ])
+                    }
+                    
+                    it("disabled") {
+                        XCTAssertEqual(enabled.events, [
+                            next(0, false),
+                        ])
+                    }
+                    
+                    it("never be executing") {
+                        XCTAssertEqual(executing.events, [
+                            next(0, false),
+                        ])
+                    }
+                }
+
+                var action: Action<String, String>!
+
+                beforeEach {
+                    action = Action(enabledIf: Observable.just(false)) { Observable.just($0) }
+                    bindAction(action: action)
+                }
+
+                context("trigger via inputs subject") {
+                    beforeEach {
+                        scheduler.scheduleAt(10) { action.inputs.onNext("a") }
+                        scheduler.scheduleAt(20) { action.inputs.onNext("b") }
+                        scheduler.start()
+                    }
+
+                    itBehavesLike("send notEnabled errors to errors observable")
+                }
+
+                context("trigger via execute() method") {
+                    beforeEach {
+                        scheduler.scheduleAt(10) { action.execute("a") }
+                        scheduler.scheduleAt(20) { action.execute("b") }
+                        scheduler.start()
+                    }
+
+                    itBehavesLike("send notEnabled errors to errors observable")
+                }
+            }
+        }
+
+        describe("execute function return value") {
+            var action: Action<String, String>!
+            var element: TestableObserver<String>!
+
+            context("single element action") {
+                beforeEach {
+                    action = Action { Observable.just($0) }
+                    element = scheduler.createObserver(String.self)
+                    
+                    scheduler.scheduleAt(10) {
+                        action.execute("a")
+                            .bindTo(element)
+                            .addDisposableTo(disposeBag)
+                    }
+
+                    scheduler.start()
+                }
+
+                it("element receives single value") {
+                    XCTAssertEqual(element.events, [
+                        next(10, "a"),
+                        completed(10),
+                    ])
+                }
+            }
+
+            context("multiple element action") {
+                beforeEach {
+                    action = Action { Observable.of($0, $0, $0) }
+                    element = scheduler.createObserver(String.self)
+                    
+                    scheduler.scheduleAt(10) {
+                        action.execute("a")
+                            .bindTo(element)
+                            .addDisposableTo(disposeBag)
+                    }
+
+                    scheduler.start()
+                }
+
+                it("element receives mutiple values") {
+                    XCTAssertEqual(element.events, [
+                        next(10, "a"),
+                        next(10, "a"),
+                        next(10, "a"),
+                        completed(10),
+                    ])
+                }
+            }
+
+            context("error action") {
+                beforeEach {
+                    action = Action { _ in Observable.error(TestError) }
+                    element = scheduler.createObserver(String.self)
+                    
+                    scheduler.scheduleAt(10) {
+                        action.execute("a")
+                            .bindTo(element)
+                            .addDisposableTo(disposeBag)
+                    }
+
+                    scheduler.start()
+                }
+
+                it("element fails with underlyingError") {
+                    XCTAssertEqual(element.events, [
+                        error(10, ActionError.underlyingError(TestError))
+                    ])
+                }
+            }
+
+            context("disabled") {
+                beforeEach {
+                    action = Action(enabledIf: Observable.just(false)) { Observable.just($0) }
+                    element = scheduler.createObserver(String.self)
+                    
+                    scheduler.scheduleAt(10) {
+                        action.execute("a")
+                            .bindTo(element)
+                            .addDisposableTo(disposeBag)
+                    }
+
+                    scheduler.start()
+                }
+
+                it("element fails with notEnabled") {
+                    XCTAssertEqual(element.events, [
+                        error(10, ActionError.notEnabled)
+                    ])
+                }
+            }
         }
 
         it("sends errors on errors observable as Next events") {
@@ -408,7 +823,19 @@ class ActionTests: QuickSpec {
     }
 }
 
-
+extension ActionError: Equatable {
+    // Not accurate but convenient for testing.
+    public static func ==(lhs: ActionError, rhs: ActionError) -> Bool {
+        switch (lhs, rhs) {
+        case (.notEnabled, .notEnabled):
+            return true
+        case (.underlyingError, .underlyingError):
+            return true
+        default:
+            return false
+        }
+    }
+}
 
 extension String: Error { }
 let TestError = "Test Error"

--- a/UIBarButtonItem+Action.swift
+++ b/UIBarButtonItem+Action.swift
@@ -11,32 +11,28 @@ public extension Reactive where Base: UIBarButtonItem {
     public var action: CocoaAction? {
         get {
             var action: CocoaAction?
-            doLocked {
-                action = objc_getAssociatedObject(self.base, &AssociatedKeys.Action) as? Action
-            }
+            action = objc_getAssociatedObject(self.base, &AssociatedKeys.Action) as? Action
             return action
         }
 
         set {
-            doLocked {
-                // Store new value.
-                objc_setAssociatedObject(self.base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-
-                // This effectively disposes of any existing subscriptions.
-                self.base.resetActionDisposeBag()
-
-                // Set up new bindings, if applicable.
-                if let action = newValue {
-                    action
-                        .enabled
-                        .bindTo(self.isEnabled)
-                        .addDisposableTo(self.base.actionDisposeBag)
-
-                    self.tap.subscribe(onNext: { (_) in
-                        action.execute()
-                    })
+            // Store new value.
+            objc_setAssociatedObject(self.base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            
+            // This effectively disposes of any existing subscriptions.
+            self.base.resetActionDisposeBag()
+            
+            // Set up new bindings, if applicable.
+            if let action = newValue {
+                action
+                    .enabled
+                    .bindTo(self.isEnabled)
                     .addDisposableTo(self.base.actionDisposeBag)
-                }
+                
+                self.tap.subscribe(onNext: { (_) in
+                    action.execute()
+                })
+                    .addDisposableTo(self.base.actionDisposeBag)
             }
         }
     }

--- a/UIButton+Rx.swift
+++ b/UIButton+Rx.swift
@@ -10,47 +10,43 @@ public extension Reactive where Base: UIButton {
     public var action: CocoaAction? {
         get {
             var action: CocoaAction?
-            doLocked {
-                action = objc_getAssociatedObject(self.base, &AssociatedKeys.Action) as? Action
-            }
+            action = objc_getAssociatedObject(self.base, &AssociatedKeys.Action) as? Action
             return action
         }
 
         set {
-            doLocked {
-                // Store new value.
-                objc_setAssociatedObject(self.base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-
-                // This effectively disposes of any existing subscriptions.
-                self.base.resetActionDisposeBag()
-
-                // Set up new bindings, if applicable.
-                if let action = newValue {
-                    action
-                        .enabled
-                        .bindTo(self.isEnabled)
-                        .addDisposableTo(self.base.actionDisposeBag)
-
-                    // Technically, this file is only included on tv/iOS platforms,
-                    // so this optional will never be nil. But let's be safe 😉
-                    let lookupControlEvent: ControlEvent<Void>?
-
-                    #if os(tvOS)
-                        lookupControlEvent = self.primaryAction
-                    #elseif os(iOS)
-                        lookupControlEvent = self.tap
-                    #endif
-
-                    guard let controlEvent = lookupControlEvent else {
-                        return
-                    }
-
-                    controlEvent
-                        .subscribe(onNext: {
-                            action.execute()
-                        })
-                        .addDisposableTo(self.base.actionDisposeBag)
+            // Store new value.
+            objc_setAssociatedObject(self.base, &AssociatedKeys.Action, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            
+            // This effectively disposes of any existing subscriptions.
+            self.base.resetActionDisposeBag()
+            
+            // Set up new bindings, if applicable.
+            if let action = newValue {
+                action
+                    .enabled
+                    .bindTo(self.isEnabled)
+                    .addDisposableTo(self.base.actionDisposeBag)
+                
+                // Technically, this file is only included on tv/iOS platforms,
+                // so this optional will never be nil. But let's be safe 😉
+                let lookupControlEvent: ControlEvent<Void>?
+                
+                #if os(tvOS)
+                    lookupControlEvent = self.primaryAction
+                #elseif os(iOS)
+                    lookupControlEvent = self.tap
+                #endif
+                
+                guard let controlEvent = lookupControlEvent else {
+                    return
                 }
+                
+                controlEvent
+                    .subscribe(onNext: {
+                        action.execute()
+                    })
+                    .addDisposableTo(self.base.actionDisposeBag)
             }
         }
     }


### PR DESCRIPTION
This PR refactors internal implementation to focus more on observables.
No public APIs are changed, and all existing test cases are retained.

The changes minimize:

- Use of private subjects
- Stored properties that manage state
- Manual locking

If we should avoid significant internal changes in this minor version, I'll work for the next major version.
