### PR TITLE
Fix build warnings

### DIFF
--- a/Action.xcodeproj/project.pbxproj
+++ b/Action.xcodeproj/project.pbxproj
@@ -429,10 +429,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Checkouts/RxSwift/build/Debug",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/Action/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "-.Tests";
@@ -448,10 +445,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Checkouts/RxSwift/build/Debug",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/Action/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "-.Tests";

--- a/Tests/Action/ActionTests.swift
+++ b/Tests/Action/ActionTests.swift
@@ -293,10 +293,8 @@ class ActionTests: QuickSpec {
                 }
 
                 it("is externally disabled while executing") {
-                    var observer: AnyObserver<Void>!
                     let subject = Action<Void, Void>(workFactory: { _ in
                         return Observable.create { (obsv) -> Disposable in
-                            observer = obsv
                             return Disposables.create()
                         }
                     })


### PR DESCRIPTION
This PR fixes following warnings:
- Tests/Action/ActionTests.swift:296:25: Variable 'observer' was written to, but never read
- ld: warning: directory not found for option '-FCarthage/Checkouts/RxSwift/build/Debug'
