### PR TITLE
Update documentation for rx.action

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ Note that `enabledIf` isn't the same as the `enabled` property. You pass in `ena
 What's _really_ cool is the `UIButton` extension. It accepts a `CocoaAction`, which is just `Action<Void, Void>`.
 
 ```swift
-button.rx_action = action
+button.rx.action = action
 ```
 
 Now when the button is pressed, the action is executed. The button's `enabled` state is bound to the action's `enabled` property. That means you can feed your form-validation logic into the action as a signal, and your button's enabled state is handled for you. Also, the user can't press the button again before the action is done executing, since it only handles one thing at a time. Cool. Check out [this code example of CocoaAction _in_ action](https://github.com/artsy/eidolon/blob/cb31168fa29dcc7815fd4a2e30e7c000bd1820ce/Kiosk/Bid%20Fulfillment/GenericFormValidationViewModel.swift).

--- a/Sources/Action/Action+Internal.swift
+++ b/Sources/Action/Action+Internal.swift
@@ -10,7 +10,7 @@ internal struct AssociatedKeys {
 // So be careful!
 internal extension NSObject {
 
-    // A dispose bag to be used exclusively for the instance's rx_action.
+    // A dispose bag to be used exclusively for the instance's rx.action.
     internal var actionDisposeBag: DisposeBag {
         var disposeBag: DisposeBag
 

--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -2,7 +2,7 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-/// Typealias for compatibility with UIButton's rx_action property.
+/// Typealias for compatibility with UIButton's rx.action property.
 public typealias CocoaAction = Action<Void, Void>
 
 /// Possible errors from invoking execute()

--- a/Sources/Action/UIKitExtensions/AlertAction.swift
+++ b/Sources/Action/UIKitExtensions/AlertAction.swift
@@ -17,7 +17,7 @@ public extension Reactive where Base: UIAlertAction {
 
     /// Binds enabled state of action to button, and subscribes to rx_tap to execute action.
     /// These subscriptions are managed in a private, inaccessible dispose bag. To cancel
-    /// them, set the rx_action to nil or another action.
+    /// them, set the rx.action to nil or another action.
     public var action: CocoaAction? {
         get {
             var action: CocoaAction?

--- a/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
+++ b/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
@@ -8,7 +8,7 @@ public extension Reactive where Base: UIBarButtonItem {
 
     /// Binds enabled state of action to bar button item, and subscribes to rx_tap to execute action.
     /// These subscriptions are managed in a private, inaccessible dispose bag. To cancel
-    /// them, set the rx_action to nil or another action.
+    /// them, set the rx.action to nil or another action.
     public var action: CocoaAction? {
         get {
             var action: CocoaAction?

--- a/Sources/Action/UIKitExtensions/UIButton+Rx.swift
+++ b/Sources/Action/UIKitExtensions/UIButton+Rx.swift
@@ -7,7 +7,7 @@ import ObjectiveC
 public extension Reactive where Base: UIButton {
     /// Binds enabled state of action to button, and subscribes to rx_tap to execute action.
     /// These subscriptions are managed in a private, inaccessible dispose bag. To cancel
-    /// them, set the rx_action to nil or another action.
+    /// them, set the rx.action to nil or another action.
     public var action: CocoaAction? {
         get {
             var action: CocoaAction?


### PR DESCRIPTION
Updated documentation from `rx_action` to `rx.action`.

Fixes #52.