### PR TITLE
Not replay executionObservables for execute()

### DIFF
--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -72,7 +72,7 @@ public final class Action<Input, Element> {
                     return Observable.empty()
                 }
             }
-            .shareReplay(1)
+            .share()
 
         elements = executionObservables
             .flatMap { $0.catchError { _ in Observable.empty() } }


### PR DESCRIPTION
I found second call of `execute()` returns the same output which the first time returned.
This issue started to happen from version 2.1.0, and doesn't happen when one use `input` only.

This issue is caused by replaying execution observable. To fix this issue, this PR replaces `sharedReplay(1)` of `executionObservable` with `share()` so that `execute()` returns always return the latest execution observable.

I'm sorry for overlooking this issue.
I've also update unit tests to detect the same kind of issue.
