### PR TITLE
Rewrite executing observable

### DIFF
--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -38,7 +38,6 @@ public final class Action<Input, Element> {
     public let elements: Observable<Element>
 
     /// Whether or not we're currently executing. 
-    /// Always observed on MainScheduler.
     public let executing: Observable<Bool>
 
     /// Observables returned by the workFactory.

--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -98,10 +98,14 @@ public final class Action<Input, Element> {
             .merge()
 
         executing = executionObservables.flatMap {
-                Observable.concat([
-                    Observable.just(true),
-                    $0.ignoreElements().map { _ in true }.catchError { _ in Observable.empty() },
-                    Observable.just(false)])
+                execution -> Observable<Bool> in
+                let execution = execution
+                    .flatMap { _ in Observable<Bool>.empty() }
+                    .catchError { _ in Observable.empty()}
+
+                return Observable.concat([Observable.just(true),
+                                          execution,
+                                          Observable.just(false)])
             }
             .startWith(false)
             .shareReplay(1)
@@ -117,7 +121,7 @@ public final class Action<Input, Element> {
         defer {
             inputs.onNext(value)
         }
-        
+
         let execution = executionObservables
             .take(1)
             .flatMap { $0 }

--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -98,10 +98,10 @@ public final class Action<Input, Element> {
             .merge()
 
         executing = executionObservables.flatMap {
-                Observable
-                    .just(true)
-                    .concat($0.ignoreElements().map { _ in true }.catchError { _ in Observable.empty() })
-                    .concat(Observable.just(false))
+                Observable.concat([
+                    Observable.just(true),
+                    $0.ignoreElements().map { _ in true }.catchError { _ in Observable.empty() },
+                    Observable.just(false)])
             }
             .startWith(false)
             .shareReplay(1)


### PR DESCRIPTION
Rewrote the `executing` observable, leading to simpler code.

Also Integrated @stefanomondomino's idea of using a `shareReplay(1)` to guarantee that late subscribers get the current execution state.