### PR TITLE
bindToAction

### DIFF
--- a/Action.xcodeproj/project.pbxproj
+++ b/Action.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3D37A3961DB4A97C0028BC0E /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D9C98331DB4A87B004A9F7C /* RxTest.framework */; };
+		7BD1C7551E1D5562000D82DA /* UIControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD1C7541E1D5562000D82DA /* UIControl+Rx.swift */; };
 		7F0569E81DE28587007E1D0D /* Action+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E01DE28587007E1D0D /* Action+Internal.swift */; };
 		7F0569E91DE28587007E1D0D /* Action.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F0569E11DE28587007E1D0D /* Action.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7F0569EA1DE28587007E1D0D /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E21DE28587007E1D0D /* Action.swift */; };
@@ -72,6 +73,7 @@
 
 /* Begin PBXFileReference section */
 		3D9C98331DB4A87B004A9F7C /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Checkouts/RxSwift/build/Debug/RxTest.framework; sourceTree = "<group>"; };
+		7BD1C7541E1D5562000D82DA /* UIControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+Rx.swift"; sourceTree = "<group>"; };
 		7F0569E01DE28587007E1D0D /* Action+Internal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Action+Internal.swift"; sourceTree = "<group>"; };
 		7F0569E11DE28587007E1D0D /* Action.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Action.h; sourceTree = "<group>"; };
 		7F0569E21DE28587007E1D0D /* Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
@@ -164,6 +166,7 @@
 				7F0569E51DE28587007E1D0D /* AlertAction.swift */,
 				7F0569E61DE28587007E1D0D /* UIBarButtonItem+Action.swift */,
 				7F0569E71DE28587007E1D0D /* UIButton+Rx.swift */,
+				7BD1C7541E1D5562000D82DA /* UIControl+Rx.swift */,
 			);
 			path = UIKitExtensions;
 			sourceTree = "<group>";
@@ -404,6 +407,7 @@
 				7F0569EC1DE28587007E1D0D /* AlertAction.swift in Sources */,
 				7F0569E81DE28587007E1D0D /* Action+Internal.swift in Sources */,
 				7F0569ED1DE28587007E1D0D /* UIBarButtonItem+Action.swift in Sources */,
+				7BD1C7551E1D5562000D82DA /* UIControl+Rx.swift in Sources */,
 				7F0569EA1DE28587007E1D0D /* Action.swift in Sources */,
 				7F0569EE1DE28587007E1D0D /* UIButton+Rx.swift in Sources */,
 			);

--- a/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Base.lproj/Main.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="gBp-2p-Zj2">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="gBp-2p-Zj2">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
@@ -31,28 +35,38 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="64" width="600" height="536"/>
+                        <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SZL-3G-VZh">
-                                <rect key="frame" x="264" y="31" width="73" height="30"/>
-                                <animations/>
+                                <rect key="frame" x="151" y="31" width="73" height="30"/>
                                 <state key="normal" title="Show alert"/>
                             </button>
-                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Doing some work" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ulN-2s-mAd">
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Doing some work" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ulN-2s-mAd">
                                 <rect key="frame" x="234" y="467" width="133" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="OrY-7C-i77">
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="OrY-7C-i77">
                                 <rect key="frame" x="290" y="496" width="20" height="20"/>
                             </activityIndicatorView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rn7-U4-1tI">
+                                <rect key="frame" x="131" y="107" width="113" height="30"/>
+                                <state key="normal" title="Custom button 1"/>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KoY-Sn-0Iw">
+                                <rect key="frame" x="130" y="145" width="115" height="30"/>
+                                <state key="normal" title="Custom button 2"/>
+                            </button>
                         </subviews>
-                        <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="Rn7-U4-1tI" firstAttribute="centerX" secondItem="SZL-3G-VZh" secondAttribute="centerX" id="2z3-Ib-Bzb"/>
                             <constraint firstItem="OrY-7C-i77" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Dyl-A6-bud"/>
+                            <constraint firstItem="KoY-Sn-0Iw" firstAttribute="centerX" secondItem="Rn7-U4-1tI" secondAttribute="centerX" id="Esh-u5-4Vv"/>
+                            <constraint firstItem="KoY-Sn-0Iw" firstAttribute="top" secondItem="Rn7-U4-1tI" secondAttribute="bottom" constant="8" id="Gph-05-VIV"/>
+                            <constraint firstItem="Rn7-U4-1tI" firstAttribute="top" secondItem="SZL-3G-VZh" secondAttribute="bottom" constant="46" id="Hhn-4d-Hi7"/>
                             <constraint firstItem="SZL-3G-VZh" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="31" id="Np0-fa-c3f"/>
                             <constraint firstItem="ulN-2s-mAd" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="a5T-qt-gDR"/>
                             <constraint firstItem="OrY-7C-i77" firstAttribute="top" secondItem="ulN-2s-mAd" secondAttribute="bottom" constant="8" id="eqf-Tp-OJd"/>
@@ -62,11 +76,14 @@
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationItem key="navigationItem" title="Action demo" id="6DL-Fh-JcF">
+                        <barButtonItem key="leftBarButtonItem" title="Custom3" id="piR-Gf-7t2"/>
                         <barButtonItem key="rightBarButtonItem" title="Bar Item" id="7hK-lr-Izl"/>
                     </navigationItem>
                     <connections>
                         <outlet property="activityIndicator" destination="OrY-7C-i77" id="VCS-wT-Lb8"/>
                         <outlet property="button" destination="SZL-3G-VZh" id="IT1-GJ-Qic"/>
+                        <outlet property="button1" destination="Rn7-U4-1tI" id="zLN-qN-lSH"/>
+                        <outlet property="button2" destination="KoY-Sn-0Iw" id="AUC-hM-Glv"/>
                         <outlet property="workingLabel" destination="ulN-2s-mAd" id="17Y-xo-0lM"/>
                     </connections>
                 </viewController>

--- a/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
+++ b/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
@@ -42,16 +42,16 @@ public extension Reactive where Base: UIBarButtonItem {
         
         self.base.resetActionDisposeBag()
         
-        if (action == nil) {
+        guard let action = action else {
             return
         }
         
         self.tap
             .map { return inputTransform(self.base) }
-            .bindTo(action!.inputs)
+            .bindTo(action.inputs)
             .addDisposableTo(self.base.actionDisposeBag)
         
-        action!
+        action
             .enabled
             .bindTo(self.isEnabled)
             .addDisposableTo(self.base.actionDisposeBag)

--- a/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
+++ b/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
@@ -4,6 +4,7 @@ import RxSwift
 import RxCocoa
 import ObjectiveC
 
+
 public extension Reactive where Base: UIBarButtonItem {
 
     /// Binds enabled state of action to bar button item, and subscribes to rx_tap to execute action.
@@ -37,5 +38,28 @@ public extension Reactive where Base: UIBarButtonItem {
             }
         }
     }
+    public func bindToAction <Input,Output>(_ action:Action<Input,Output>?,_ inputTransform: @escaping (Base) -> (Input))   {
+        
+        self.base.resetActionDisposeBag()
+        
+        if (action == nil) {
+            return
+        }
+        
+        self.tap
+            .map { return inputTransform(self.base) }
+            .bindTo(action!.inputs)
+            .addDisposableTo(self.base.actionDisposeBag)
+        
+        action!
+            .enabled
+            .bindTo(self.isEnabled)
+            .addDisposableTo(self.base.actionDisposeBag)
+        
+    }
+    public func bindToAction <Input,Output>(_ action:Action<Input,Output>?, input:Input) {
+        self.bindToAction(action) {_ in return input}
+    }
+    
 }
 #endif

--- a/Sources/Action/UIKitExtensions/UIButton+Rx.swift
+++ b/Sources/Action/UIKitExtensions/UIButton+Rx.swift
@@ -51,5 +51,52 @@ public extension Reactive where Base: UIButton {
             }
         }
     }
+    
+    /// Binds enabled state of action to button, and subscribes to rx_tap to execute action with given input transform.
+    /// These subscriptions are managed in a private, inaccessible dispose bag. To cancel
+    /// them, call bindToAction with another action or nil.
+    public func bindToAction <Input,Output>(_ action:Action<Input,Output>?,_ inputTransform: @escaping (Base) -> (Input))   {
+        // This effectively disposes of any existing subscriptions.
+        self.base.resetActionDisposeBag()
+        
+        
+        // If no action is provided, there is nothing left to do. All previous subscriptions are disposed.
+        if (action == nil) {
+            return
+        }
+        // Technically, this file is only included on tv/iOS platforms,
+        // so this optional will never be nil. But let's be safe 😉
+        let lookupControlEvent: ControlEvent<Void>?
+        
+        #if os(tvOS)
+            lookupControlEvent = self.primaryAction
+        #elseif os(iOS)
+            lookupControlEvent = self.tap
+        #endif
+        
+        guard let controlEvent = lookupControlEvent else {
+            return
+        }
+        // For each tap event, use the inputTransform closure to provide an Input value to the action
+        controlEvent
+            .map { return inputTransform(self.base) }
+            .bindTo(action!.inputs)
+            .addDisposableTo(self.base.actionDisposeBag)
+        
+        // Bind the enabled state of the control to the enabled state of the action
+        action!
+            .enabled
+            .bindTo(self.isEnabled)
+            .addDisposableTo(self.base.actionDisposeBag)
+        
+    }
+    
+    /// Binds enabled state of action to button, and subscribes to rx_tap to execute action with given input value.
+    /// These subscriptions are managed in a private, inaccessible dispose bag. To cancel
+    /// them, call bindToAction with another action or nil.
+    public func bindToAction <Input,Output>(_ action:Action<Input,Output>?, input:Input) {
+        self.bindToAction(action) {_ in return input}
+    }
+    
 }
 #endif

--- a/Sources/Action/UIKitExtensions/UIButton+Rx.swift
+++ b/Sources/Action/UIKitExtensions/UIButton+Rx.swift
@@ -57,13 +57,7 @@ public extension Reactive where Base: UIButton {
     /// them, call bindToAction with another action or nil.
     public func bindToAction <Input,Output>(_ action:Action<Input,Output>?,_ inputTransform: @escaping (Base) -> (Input))   {
         // This effectively disposes of any existing subscriptions.
-        self.base.resetActionDisposeBag()
-        
-        
-        // If no action is provided, there is nothing left to do. All previous subscriptions are disposed.
-        if (action == nil) {
-            return
-        }
+     
         // Technically, this file is only included on tv/iOS platforms,
         // so this optional will never be nil. But let's be safe 😉
         let lookupControlEvent: ControlEvent<Void>?
@@ -77,17 +71,7 @@ public extension Reactive where Base: UIButton {
         guard let controlEvent = lookupControlEvent else {
             return
         }
-        // For each tap event, use the inputTransform closure to provide an Input value to the action
-        controlEvent
-            .map { return inputTransform(self.base) }
-            .bindTo(action!.inputs)
-            .addDisposableTo(self.base.actionDisposeBag)
-        
-        // Bind the enabled state of the control to the enabled state of the action
-        action!
-            .enabled
-            .bindTo(self.isEnabled)
-            .addDisposableTo(self.base.actionDisposeBag)
+        self.bindToAction(action, controlEvent: controlEvent, inputTransform)
         
     }
     

--- a/Sources/Action/UIKitExtensions/UIControl+Rx.swift
+++ b/Sources/Action/UIKitExtensions/UIControl+Rx.swift
@@ -1,0 +1,38 @@
+#if os(iOS) || os(tvOS)
+import UIKit
+import RxSwift
+import RxCocoa
+import ObjectiveC
+
+public extension Reactive where Base : UIControl {
+    /// Binds enabled state of action to control, and subscribes action's execution to provided controlEvents.
+    /// These subscriptions are managed in a private, inaccessible dispose bag. To cancel
+    /// them, set the rx.action to nil or another action.
+    public func bindToAction <Input,Output>(_ action:Action<Input,Output>?, controlEvent:ControlEvent<Void>, _ inputTransform: @escaping (Base) -> (Input))   {
+        // This effectively disposes of any existing subscriptions.
+        self.base.resetActionDisposeBag()
+        
+        
+        // If no action is provided, there is nothing left to do. All previous subscriptions are disposed.
+        guard let action = action else {
+            return
+        }
+        // Technically, this file is only included on tv/iOS platforms,
+        // so this optional will never be nil. But let's be safe 😉
+        
+        // For each tap event, use the inputTransform closure to provide an Input value to the action
+        controlEvent
+            .map { return inputTransform(self.base) }
+            .bindTo(action.inputs)
+            .addDisposableTo(self.base.actionDisposeBag)
+        
+        // Bind the enabled state of the control to the enabled state of the action
+        action
+            .enabled
+            .bindTo(self.isEnabled)
+            .addDisposableTo(self.base.actionDisposeBag)
+        
+    }
+}
+
+#endif


### PR DESCRIPTION
 bindToAction: quick way to bind a common action to a button with a input transform
As discussed in #17 , here's my idea for _something_ that should allow a control (a UIButton or UIBarButtonItem, but it could be extended)

I've updated the example with three more buttons that are connected to the same action while giving three distinct inputs. No CocoaActions are involved at all. I'm afraid naming needs review :(