### PR TITLE
Add Carthage Support for macOS, tvOS and watchOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,8 @@ osx_image: xcode8
 script: 
   - set -o pipefail
   - xcodebuild build-for-testing test-without-building -workspace Action.xcworkspace -scheme Action -sdk iphonesimulator -destination "name=iPhone SE" | xcpretty -c
+  - xcodebuild build -workspace Action.xcworkspace -scheme Action-watchOS -sdk watchsimulator -destination "name=Apple Watch - 38mm" | xcpretty -c
+  - xcodebuild build -workspace Action.xcworkspace -scheme Action-macOS -sdk macosx -destination "arch=x86_64" | xcpretty -c
+  - xcodebuild build -workspace Action.xcworkspace -scheme Action-tvOS -sdk appletvsimulator -destination "name=Apple TV 1080p" | xcpretty -c
   - swift build
 

--- a/Action.xcodeproj/project.pbxproj
+++ b/Action.xcodeproj/project.pbxproj
@@ -7,6 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1FCDDA631EAC31DD006EB95B /* Action.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F0569E11DE28587007E1D0D /* Action.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1FCDDA641EAC31EF006EB95B /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E21DE28587007E1D0D /* Action.swift */; };
+		1FCDDA651EAC31EF006EB95B /* Action+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E01DE28587007E1D0D /* Action+Internal.swift */; };
+		1FCDDA661EAC31EF006EB95B /* AlertAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E51DE28587007E1D0D /* AlertAction.swift */; };
+		1FCDDA671EAC31EF006EB95B /* UIBarButtonItem+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E61DE28587007E1D0D /* UIBarButtonItem+Action.swift */; };
+		1FCDDA681EAC31EF006EB95B /* UIButton+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E71DE28587007E1D0D /* UIButton+Rx.swift */; };
+		1FCDDA691EAC31EF006EB95B /* UIControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD1C7541E1D5562000D82DA /* UIControl+Rx.swift */; };
+		1FCDDA6C1EAC3221006EB95B /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCDDA6A1EAC3221006EB95B /* RxCocoa.framework */; };
+		1FCDDA6D1EAC3221006EB95B /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCDDA6B1EAC3221006EB95B /* RxSwift.framework */; };
 		3D37A3961DB4A97C0028BC0E /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D9C98331DB4A87B004A9F7C /* RxTest.framework */; };
 		5ED520241E1EA199007621B9 /* BindToTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED520231E1EA199007621B9 /* BindToTests.swift */; };
 		7BD1C7551E1D5562000D82DA /* UIControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD1C7541E1D5562000D82DA /* UIControl+Rx.swift */; };
@@ -71,6 +80,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1FCDDA5B1EAC315A006EB95B /* Action.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Action.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1FCDDA6A1EAC3221006EB95B /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = "Carthage/Checkouts/RxSwift/build/Debug-appletvos/RxCocoa.framework"; sourceTree = "<group>"; };
+		1FCDDA6B1EAC3221006EB95B /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = "Carthage/Checkouts/RxSwift/build/Debug-appletvos/RxSwift.framework"; sourceTree = "<group>"; };
 		3D9C98331DB4A87B004A9F7C /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Checkouts/RxSwift/build/Debug/RxTest.framework; sourceTree = "<group>"; };
 		5ED520231E1EA199007621B9 /* BindToTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BindToTests.swift; path = ActionTests/BindToTests.swift; sourceTree = "<group>"; };
 		7BD1C7541E1D5562000D82DA /* UIControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+Rx.swift"; sourceTree = "<group>"; };
@@ -103,6 +115,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1FCDDA571EAC315A006EB95B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1FCDDA6C1EAC3221006EB95B /* RxCocoa.framework in Frameworks */,
+				1FCDDA6D1EAC3221006EB95B /* RxSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7F5E6A641D7F08D2000B6076 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -181,6 +202,8 @@
 		7F5E6A5C1D7F06C4000B6076 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1FCDDA6A1EAC3221006EB95B /* RxCocoa.framework */,
+				1FCDDA6B1EAC3221006EB95B /* RxSwift.framework */,
 				3D9C98331DB4A87B004A9F7C /* RxTest.framework */,
 				7F612ABB1D7F10C900B93BC5 /* Nimble.framework */,
 				7F612AB91D7F10C000B93BC5 /* Quick.framework */,
@@ -234,6 +257,7 @@
 				BE73AD201CDCD101006F8B98 /* Action.framework */,
 				7F5E6A671D7F08D2000B6076 /* Tests.xctest */,
 				7F612ACC1D7F13B800B93BC5 /* Demo.app */,
+				1FCDDA5B1EAC315A006EB95B /* Action.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -241,6 +265,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		1FCDDA581EAC315A006EB95B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1FCDDA631EAC31DD006EB95B /* Action.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BE73AD1D1CDCD101006F8B98 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -252,6 +284,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		1FCDDA5A1EAC315A006EB95B /* Action-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1FCDDA621EAC315A006EB95B /* Build configuration list for PBXNativeTarget "Action-tvOS" */;
+			buildPhases = (
+				1FCDDA561EAC315A006EB95B /* Sources */,
+				1FCDDA571EAC315A006EB95B /* Frameworks */,
+				1FCDDA581EAC315A006EB95B /* Headers */,
+				1FCDDA591EAC315A006EB95B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Action-tvOS";
+			productName = "Action-tvOS";
+			productReference = 1FCDDA5B1EAC315A006EB95B /* Action.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		7F5E6A661D7F08D2000B6076 /* Tests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7F5E6A6F1D7F08D2000B6076 /* Build configuration list for PBXNativeTarget "Tests" */;
@@ -316,6 +366,10 @@
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = CezaryKopacz;
 				TargetAttributes = {
+					1FCDDA5A1EAC315A006EB95B = {
+						CreatedOnToolsVersion = 8.3.2;
+						ProvisioningStyle = Automatic;
+					};
 					7F5E6A661D7F08D2000B6076 = {
 						CreatedOnToolsVersion = 8.0;
 						LastSwiftMigration = 0810;
@@ -345,6 +399,7 @@
 			projectRoot = "";
 			targets = (
 				BE73AD1F1CDCD101006F8B98 /* Action */,
+				1FCDDA5A1EAC315A006EB95B /* Action-tvOS */,
 				7F5E6A661D7F08D2000B6076 /* Tests */,
 				7F612ACB1D7F13B800B93BC5 /* Demo */,
 			);
@@ -352,6 +407,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1FCDDA591EAC315A006EB95B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7F5E6A651D7F08D2000B6076 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -379,6 +441,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1FCDDA561EAC315A006EB95B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1FCDDA641EAC31EF006EB95B /* Action.swift in Sources */,
+				1FCDDA651EAC31EF006EB95B /* Action+Internal.swift in Sources */,
+				1FCDDA661EAC31EF006EB95B /* AlertAction.swift in Sources */,
+				1FCDDA671EAC31EF006EB95B /* UIBarButtonItem+Action.swift in Sources */,
+				1FCDDA681EAC31EF006EB95B /* UIButton+Rx.swift in Sources */,
+				1FCDDA691EAC31EF006EB95B /* UIControl+Rx.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7F5E6A631D7F08D2000B6076 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -443,6 +518,59 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		1FCDDA601EAC315A006EB95B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Checkouts/RxSwift/build/Debug-appletvos",
+				);
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = jp.toshi0383.Action;
+				PRODUCT_NAME = Action;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		1FCDDA611EAC315A006EB95B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Checkouts/RxSwift/build/Debug-appletvos",
+				);
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = jp.toshi0383.Action;
+				PRODUCT_NAME = Action;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 		7F5E6A701D7F08D2000B6076 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -544,6 +672,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Sources/Action/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -590,6 +719,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Sources/Action/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
@@ -612,7 +742,6 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = Sources/Action/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ashfurrow.Action;
@@ -632,7 +761,6 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = Sources/Action/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ashfurrow.Action;
@@ -644,6 +772,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1FCDDA621EAC315A006EB95B /* Build configuration list for PBXNativeTarget "Action-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1FCDDA601EAC315A006EB95B /* Debug */,
+				1FCDDA611EAC315A006EB95B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		7F5E6A6F1D7F08D2000B6076 /* Build configuration list for PBXNativeTarget "Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Action.xcodeproj/project.pbxproj
+++ b/Action.xcodeproj/project.pbxproj
@@ -16,6 +16,11 @@
 		1FCDDA691EAC31EF006EB95B /* UIControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD1C7541E1D5562000D82DA /* UIControl+Rx.swift */; };
 		1FCDDA6C1EAC3221006EB95B /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCDDA6A1EAC3221006EB95B /* RxCocoa.framework */; };
 		1FCDDA6D1EAC3221006EB95B /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCDDA6B1EAC3221006EB95B /* RxSwift.framework */; };
+		1FCDDA8A1EAC329E006EB95B /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E21DE28587007E1D0D /* Action.swift */; };
+		1FCDDA8B1EAC329E006EB95B /* Action+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E01DE28587007E1D0D /* Action+Internal.swift */; };
+		1FCDDA8E1EAC32AC006EB95B /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCDDA8C1EAC32AC006EB95B /* RxCocoa.framework */; };
+		1FCDDA8F1EAC32AC006EB95B /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCDDA8D1EAC32AC006EB95B /* RxSwift.framework */; };
+		1FCDDA901EAC3308006EB95B /* Action.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F0569E11DE28587007E1D0D /* Action.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3D37A3961DB4A97C0028BC0E /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D9C98331DB4A87B004A9F7C /* RxTest.framework */; };
 		5ED520241E1EA199007621B9 /* BindToTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED520231E1EA199007621B9 /* BindToTests.swift */; };
 		7BD1C7551E1D5562000D82DA /* UIControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD1C7541E1D5562000D82DA /* UIControl+Rx.swift */; };
@@ -83,6 +88,9 @@
 		1FCDDA5B1EAC315A006EB95B /* Action.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Action.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FCDDA6A1EAC3221006EB95B /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = "Carthage/Checkouts/RxSwift/build/Debug-appletvos/RxCocoa.framework"; sourceTree = "<group>"; };
 		1FCDDA6B1EAC3221006EB95B /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = "Carthage/Checkouts/RxSwift/build/Debug-appletvos/RxSwift.framework"; sourceTree = "<group>"; };
+		1FCDDA821EAC3295006EB95B /* Action.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Action.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1FCDDA8C1EAC32AC006EB95B /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Checkouts/RxSwift/build/Debug/RxCocoa.framework; sourceTree = "<group>"; };
+		1FCDDA8D1EAC32AC006EB95B /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Checkouts/RxSwift/build/Debug/RxSwift.framework; sourceTree = "<group>"; };
 		3D9C98331DB4A87B004A9F7C /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Checkouts/RxSwift/build/Debug/RxTest.framework; sourceTree = "<group>"; };
 		5ED520231E1EA199007621B9 /* BindToTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BindToTests.swift; path = ActionTests/BindToTests.swift; sourceTree = "<group>"; };
 		7BD1C7541E1D5562000D82DA /* UIControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+Rx.swift"; sourceTree = "<group>"; };
@@ -121,6 +129,15 @@
 			files = (
 				1FCDDA6C1EAC3221006EB95B /* RxCocoa.framework in Frameworks */,
 				1FCDDA6D1EAC3221006EB95B /* RxSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FCDDA7E1EAC3295006EB95B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1FCDDA8E1EAC32AC006EB95B /* RxCocoa.framework in Frameworks */,
+				1FCDDA8F1EAC32AC006EB95B /* RxSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -202,6 +219,8 @@
 		7F5E6A5C1D7F06C4000B6076 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1FCDDA8C1EAC32AC006EB95B /* RxCocoa.framework */,
+				1FCDDA8D1EAC32AC006EB95B /* RxSwift.framework */,
 				1FCDDA6A1EAC3221006EB95B /* RxCocoa.framework */,
 				1FCDDA6B1EAC3221006EB95B /* RxSwift.framework */,
 				3D9C98331DB4A87B004A9F7C /* RxTest.framework */,
@@ -258,6 +277,7 @@
 				7F5E6A671D7F08D2000B6076 /* Tests.xctest */,
 				7F612ACC1D7F13B800B93BC5 /* Demo.app */,
 				1FCDDA5B1EAC315A006EB95B /* Action.framework */,
+				1FCDDA821EAC3295006EB95B /* Action.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -270,6 +290,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				1FCDDA631EAC31DD006EB95B /* Action.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FCDDA7F1EAC3295006EB95B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1FCDDA901EAC3308006EB95B /* Action.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -300,6 +328,24 @@
 			name = "Action-tvOS";
 			productName = "Action-tvOS";
 			productReference = 1FCDDA5B1EAC315A006EB95B /* Action.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		1FCDDA811EAC3295006EB95B /* Action-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1FCDDA871EAC3295006EB95B /* Build configuration list for PBXNativeTarget "Action-macOS" */;
+			buildPhases = (
+				1FCDDA7D1EAC3295006EB95B /* Sources */,
+				1FCDDA7E1EAC3295006EB95B /* Frameworks */,
+				1FCDDA7F1EAC3295006EB95B /* Headers */,
+				1FCDDA801EAC3295006EB95B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Action-macOS";
+			productName = "Action-macOS";
+			productReference = 1FCDDA821EAC3295006EB95B /* Action.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		7F5E6A661D7F08D2000B6076 /* Tests */ = {
@@ -370,6 +416,10 @@
 						CreatedOnToolsVersion = 8.3.2;
 						ProvisioningStyle = Automatic;
 					};
+					1FCDDA811EAC3295006EB95B = {
+						CreatedOnToolsVersion = 8.3.2;
+						ProvisioningStyle = Automatic;
+					};
 					7F5E6A661D7F08D2000B6076 = {
 						CreatedOnToolsVersion = 8.0;
 						LastSwiftMigration = 0810;
@@ -400,6 +450,7 @@
 			targets = (
 				BE73AD1F1CDCD101006F8B98 /* Action */,
 				1FCDDA5A1EAC315A006EB95B /* Action-tvOS */,
+				1FCDDA811EAC3295006EB95B /* Action-macOS */,
 				7F5E6A661D7F08D2000B6076 /* Tests */,
 				7F612ACB1D7F13B800B93BC5 /* Demo */,
 			);
@@ -408,6 +459,13 @@
 
 /* Begin PBXResourcesBuildPhase section */
 		1FCDDA591EAC315A006EB95B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FCDDA801EAC3295006EB95B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -451,6 +509,15 @@
 				1FCDDA671EAC31EF006EB95B /* UIBarButtonItem+Action.swift in Sources */,
 				1FCDDA681EAC31EF006EB95B /* UIButton+Rx.swift in Sources */,
 				1FCDDA691EAC31EF006EB95B /* UIControl+Rx.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FCDDA7D1EAC3295006EB95B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1FCDDA8A1EAC329E006EB95B /* Action.swift in Sources */,
+				1FCDDA8B1EAC329E006EB95B /* Action+Internal.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -528,10 +595,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Checkouts/RxSwift/build/Debug-appletvos",
-				);
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.toshi0383.Action;
@@ -555,10 +618,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Checkouts/RxSwift/build/Debug-appletvos",
-				);
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.toshi0383.Action;
@@ -568,6 +627,53 @@
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		1FCDDA881EAC3295006EB95B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.toshi0383.Action;
+				PRODUCT_NAME = Action;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		1FCDDA891EAC3295006EB95B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.toshi0383.Action;
+				PRODUCT_NAME = Action;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -741,7 +847,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ashfurrow.Action;
@@ -760,7 +865,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ashfurrow.Action;
@@ -777,6 +881,14 @@
 			buildConfigurations = (
 				1FCDDA601EAC315A006EB95B /* Debug */,
 				1FCDDA611EAC315A006EB95B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		1FCDDA871EAC3295006EB95B /* Build configuration list for PBXNativeTarget "Action-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1FCDDA881EAC3295006EB95B /* Debug */,
+				1FCDDA891EAC3295006EB95B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/Action.xcodeproj/project.pbxproj
+++ b/Action.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		1FCDDA8E1EAC32AC006EB95B /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCDDA8C1EAC32AC006EB95B /* RxCocoa.framework */; };
 		1FCDDA8F1EAC32AC006EB95B /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCDDA8D1EAC32AC006EB95B /* RxSwift.framework */; };
 		1FCDDA901EAC3308006EB95B /* Action.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F0569E11DE28587007E1D0D /* Action.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1FCDDA9E1EAC33C5006EB95B /* Action.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F0569E11DE28587007E1D0D /* Action.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1FCDDAA11EAC33D3006EB95B /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCDDA9F1EAC33D3006EB95B /* RxCocoa.framework */; };
+		1FCDDAA21EAC33D3006EB95B /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FCDDAA01EAC33D3006EB95B /* RxSwift.framework */; };
 		3D37A3961DB4A97C0028BC0E /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D9C98331DB4A87B004A9F7C /* RxTest.framework */; };
 		5ED520241E1EA199007621B9 /* BindToTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED520231E1EA199007621B9 /* BindToTests.swift */; };
 		7BD1C7551E1D5562000D82DA /* UIControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD1C7541E1D5562000D82DA /* UIControl+Rx.swift */; };
@@ -91,6 +94,9 @@
 		1FCDDA821EAC3295006EB95B /* Action.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Action.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FCDDA8C1EAC32AC006EB95B /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Checkouts/RxSwift/build/Debug/RxCocoa.framework; sourceTree = "<group>"; };
 		1FCDDA8D1EAC32AC006EB95B /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Checkouts/RxSwift/build/Debug/RxSwift.framework; sourceTree = "<group>"; };
+		1FCDDA961EAC33B0006EB95B /* Action.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Action.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1FCDDA9F1EAC33D3006EB95B /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = "Carthage/Checkouts/RxSwift/build/Debug-watchos/RxCocoa.framework"; sourceTree = "<group>"; };
+		1FCDDAA01EAC33D3006EB95B /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = "Carthage/Checkouts/RxSwift/build/Debug-watchos/RxSwift.framework"; sourceTree = "<group>"; };
 		3D9C98331DB4A87B004A9F7C /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Checkouts/RxSwift/build/Debug/RxTest.framework; sourceTree = "<group>"; };
 		5ED520231E1EA199007621B9 /* BindToTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BindToTests.swift; path = ActionTests/BindToTests.swift; sourceTree = "<group>"; };
 		7BD1C7541E1D5562000D82DA /* UIControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+Rx.swift"; sourceTree = "<group>"; };
@@ -138,6 +144,15 @@
 			files = (
 				1FCDDA8E1EAC32AC006EB95B /* RxCocoa.framework in Frameworks */,
 				1FCDDA8F1EAC32AC006EB95B /* RxSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FCDDA921EAC33B0006EB95B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1FCDDAA11EAC33D3006EB95B /* RxCocoa.framework in Frameworks */,
+				1FCDDAA21EAC33D3006EB95B /* RxSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -219,6 +234,8 @@
 		7F5E6A5C1D7F06C4000B6076 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1FCDDA9F1EAC33D3006EB95B /* RxCocoa.framework */,
+				1FCDDAA01EAC33D3006EB95B /* RxSwift.framework */,
 				1FCDDA8C1EAC32AC006EB95B /* RxCocoa.framework */,
 				1FCDDA8D1EAC32AC006EB95B /* RxSwift.framework */,
 				1FCDDA6A1EAC3221006EB95B /* RxCocoa.framework */,
@@ -278,6 +295,7 @@
 				7F612ACC1D7F13B800B93BC5 /* Demo.app */,
 				1FCDDA5B1EAC315A006EB95B /* Action.framework */,
 				1FCDDA821EAC3295006EB95B /* Action.framework */,
+				1FCDDA961EAC33B0006EB95B /* Action.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -298,6 +316,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				1FCDDA901EAC3308006EB95B /* Action.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FCDDA931EAC33B0006EB95B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1FCDDA9E1EAC33C5006EB95B /* Action.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -346,6 +372,24 @@
 			name = "Action-macOS";
 			productName = "Action-macOS";
 			productReference = 1FCDDA821EAC3295006EB95B /* Action.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		1FCDDA951EAC33B0006EB95B /* Action-watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1FCDDA9B1EAC33B0006EB95B /* Build configuration list for PBXNativeTarget "Action-watchOS" */;
+			buildPhases = (
+				1FCDDA911EAC33B0006EB95B /* Sources */,
+				1FCDDA921EAC33B0006EB95B /* Frameworks */,
+				1FCDDA931EAC33B0006EB95B /* Headers */,
+				1FCDDA941EAC33B0006EB95B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Action-watchOS";
+			productName = "Action-watchOS";
+			productReference = 1FCDDA961EAC33B0006EB95B /* Action.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		7F5E6A661D7F08D2000B6076 /* Tests */ = {
@@ -420,6 +464,10 @@
 						CreatedOnToolsVersion = 8.3.2;
 						ProvisioningStyle = Automatic;
 					};
+					1FCDDA951EAC33B0006EB95B = {
+						CreatedOnToolsVersion = 8.3.2;
+						ProvisioningStyle = Automatic;
+					};
 					7F5E6A661D7F08D2000B6076 = {
 						CreatedOnToolsVersion = 8.0;
 						LastSwiftMigration = 0810;
@@ -451,6 +499,7 @@
 				BE73AD1F1CDCD101006F8B98 /* Action */,
 				1FCDDA5A1EAC315A006EB95B /* Action-tvOS */,
 				1FCDDA811EAC3295006EB95B /* Action-macOS */,
+				1FCDDA951EAC33B0006EB95B /* Action-watchOS */,
 				7F5E6A661D7F08D2000B6076 /* Tests */,
 				7F612ACB1D7F13B800B93BC5 /* Demo */,
 			);
@@ -466,6 +515,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		1FCDDA801EAC3295006EB95B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FCDDA941EAC33B0006EB95B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -518,6 +574,13 @@
 			files = (
 				1FCDDA8A1EAC329E006EB95B /* Action.swift in Sources */,
 				1FCDDA8B1EAC329E006EB95B /* Action+Internal.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1FCDDA911EAC33B0006EB95B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -674,6 +737,53 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		1FCDDA9C1EAC33B0006EB95B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = jp.toshi0383.Action;
+				PRODUCT_NAME = Action;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		1FCDDA9D1EAC33B0006EB95B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = jp.toshi0383.Action;
+				PRODUCT_NAME = Action;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -889,6 +999,14 @@
 			buildConfigurations = (
 				1FCDDA881EAC3295006EB95B /* Debug */,
 				1FCDDA891EAC3295006EB95B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		1FCDDA9B1EAC33B0006EB95B /* Build configuration list for PBXNativeTarget "Action-watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1FCDDA9C1EAC33B0006EB95B /* Debug */,
+				1FCDDA9D1EAC33B0006EB95B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/Action.xcodeproj/xcshareddata/xcschemes/Action-macOS.xcscheme
+++ b/Action.xcodeproj/xcshareddata/xcschemes/Action-macOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0830"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1FCDDA811EAC3295006EB95B"
+               BuildableName = "Action-macOS.framework"
+               BlueprintName = "Action-macOS"
+               ReferencedContainer = "container:Action.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1FCDDA811EAC3295006EB95B"
+            BuildableName = "Action-macOS.framework"
+            BlueprintName = "Action-macOS"
+            ReferencedContainer = "container:Action.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1FCDDA811EAC3295006EB95B"
+            BuildableName = "Action-macOS.framework"
+            BlueprintName = "Action-macOS"
+            ReferencedContainer = "container:Action.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Action.xcodeproj/xcshareddata/xcschemes/Action-tvOS.xcscheme
+++ b/Action.xcodeproj/xcshareddata/xcschemes/Action-tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0830"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1FCDDA5A1EAC315A006EB95B"
+               BuildableName = "Action.framework"
+               BlueprintName = "Action-tvOS"
+               ReferencedContainer = "container:Action.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1FCDDA5A1EAC315A006EB95B"
+            BuildableName = "Action.framework"
+            BlueprintName = "Action-tvOS"
+            ReferencedContainer = "container:Action.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1FCDDA5A1EAC315A006EB95B"
+            BuildableName = "Action.framework"
+            BlueprintName = "Action-tvOS"
+            ReferencedContainer = "container:Action.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Action.xcodeproj/xcshareddata/xcschemes/Action-watchOS.xcscheme
+++ b/Action.xcodeproj/xcshareddata/xcschemes/Action-watchOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "1FCDDA951EAC33B0006EB95B"
-               BuildableName = "Action-watchOS.framework"
+               BuildableName = "Action.framework"
                BlueprintName = "Action-watchOS"
                ReferencedContainer = "container:Action.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1FCDDA951EAC33B0006EB95B"
-            BuildableName = "Action-watchOS.framework"
+            BuildableName = "Action.framework"
             BlueprintName = "Action-watchOS"
             ReferencedContainer = "container:Action.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1FCDDA951EAC33B0006EB95B"
-            BuildableName = "Action-watchOS.framework"
+            BuildableName = "Action.framework"
             BlueprintName = "Action-watchOS"
             ReferencedContainer = "container:Action.xcodeproj">
          </BuildableReference>

--- a/Action.xcodeproj/xcshareddata/xcschemes/Action-watchOS.xcscheme
+++ b/Action.xcodeproj/xcshareddata/xcschemes/Action-watchOS.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1FCDDA811EAC3295006EB95B"
-               BuildableName = "Action.framework"
-               BlueprintName = "Action-macOS"
+               BlueprintIdentifier = "1FCDDA951EAC33B0006EB95B"
+               BuildableName = "Action-watchOS.framework"
+               BlueprintName = "Action-watchOS"
                ReferencedContainer = "container:Action.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -45,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1FCDDA811EAC3295006EB95B"
-            BuildableName = "Action.framework"
-            BlueprintName = "Action-macOS"
+            BlueprintIdentifier = "1FCDDA951EAC33B0006EB95B"
+            BuildableName = "Action-watchOS.framework"
+            BlueprintName = "Action-watchOS"
             ReferencedContainer = "container:Action.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -63,9 +63,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1FCDDA811EAC3295006EB95B"
-            BuildableName = "Action.framework"
-            BlueprintName = "Action-macOS"
+            BlueprintIdentifier = "1FCDDA951EAC33B0006EB95B"
+            BuildableName = "Action-watchOS.framework"
+            BlueprintName = "Action-watchOS"
             ReferencedContainer = "container:Action.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Sources/Action/Action.h
+++ b/Sources/Action/Action.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 CezaryKopacz. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for Action.
 FOUNDATION_EXPORT double ActionVersionNumber;


### PR DESCRIPTION
Added separated targets for each platforms. Module import name is `Action`.
- Action-macOS
- Action-tvOS
- Action-watchOS

Also updated `.travis.yml` to add build check for each platforms.