### PR TITLE
addDisposableTo() to disposed(by:)

### DIFF
--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -81,7 +81,7 @@ class ViewController: UIViewController {
                     self?.activityIndicator.stopAnimating()
                 }
             })
-            .addDisposableTo(self.disposableBag)
+            .disposed(by: self.disposableBag)
 
         button1.rx.bind(to: action: sharedAction, input: .button("Button 1"))
 
@@ -97,10 +97,12 @@ class ViewController: UIViewController {
             else {
                 self?.activityIndicator.stopAnimating()
             }
-        }).addDisposableTo(self.disposableBag)
+        })
+        .disposed(by: self.disposableBag)
 
         sharedAction.elements.subscribe(onNext: { string in
             print(string  + " pressed")
-        }).addDisposableTo(self.disposableBag)
+        })
+        .disposed(by: self.disposableBag)
     }
 }

--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -98,7 +98,7 @@ public final class Action<Input, Element> {
         Observable
             .combineLatest(executing, enabledIf) { !$0 && $1 }
             .bind(to: enabledSubject)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 
     @discardableResult
@@ -119,7 +119,7 @@ public final class Action<Input, Element> {
 			.take(1)
 			.flatMap { $0 }
 			.subscribe(subject)
-			.addDisposableTo(disposeBag)
+			.disposed(by: disposeBag)
 		
 		return subject.asObservable()
     }

--- a/Sources/Action/UIKitExtensions/AlertAction.swift
+++ b/Sources/Action/UIKitExtensions/AlertAction.swift
@@ -37,7 +37,7 @@ public extension Reactive where Base: UIAlertAction {
                 action
                     .enabled
                     .bind(to: self.enabled)
-                    .addDisposableTo(self.base.actionDisposeBag)
+                    .disposed(by: self.base.actionDisposeBag)
             }
         }
     }

--- a/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
+++ b/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
@@ -28,12 +28,12 @@ public extension Reactive where Base: UIBarButtonItem {
                 action
                     .enabled
                     .bind(to: self.isEnabled)
-                    .addDisposableTo(self.base.actionDisposeBag)
+                    .disposed(by: self.base.actionDisposeBag)
                 
                 self.tap.subscribe(onNext: { (_) in
                     action.execute()
                 })
-                .addDisposableTo(self.base.actionDisposeBag)
+                .disposed(by: self.base.actionDisposeBag)
             }
         }
     }
@@ -44,12 +44,12 @@ public extension Reactive where Base: UIBarButtonItem {
         self.tap
             .map { inputTransform(self.base) }
             .bind(to: action.inputs)
-            .addDisposableTo(self.base.actionDisposeBag)
+            .disposed(by: self.base.actionDisposeBag)
 
         action
             .enabled
             .bind(to: self.isEnabled)
-            .addDisposableTo(self.base.actionDisposeBag)
+            .disposed(by: self.base.actionDisposeBag)
     }
 
     public func bind<Input, Output>(to action: Action<Input, Output>, input: Input) {

--- a/Sources/Action/UIKitExtensions/UIButton+Rx.swift
+++ b/Sources/Action/UIKitExtensions/UIButton+Rx.swift
@@ -27,7 +27,7 @@ public extension Reactive where Base: UIButton {
                 action
                     .enabled
                     .bind(to: self.isEnabled)
-                    .addDisposableTo(self.base.actionDisposeBag)
+                    .disposed(by: self.base.actionDisposeBag)
                 
                 // Technically, this file is only included on tv/iOS platforms,
                 // so this optional will never be nil. But let's be safe 😉
@@ -47,7 +47,7 @@ public extension Reactive where Base: UIButton {
                     .subscribe(onNext: {
                         action.execute()
                     })
-                    .addDisposableTo(self.base.actionDisposeBag)
+                    .disposed(by: self.base.actionDisposeBag)
             }
         }
     }

--- a/Sources/Action/UIKitExtensions/UIControl+Rx.swift
+++ b/Sources/Action/UIKitExtensions/UIControl+Rx.swift
@@ -15,13 +15,13 @@ public extension Reactive where Base: UIControl {
         controlEvent
             .map { inputTransform(self.base) }
             .bind(to: action.inputs)
-            .addDisposableTo(self.base.actionDisposeBag)
+            .disposed(by: self.base.actionDisposeBag)
 
         // Bind the enabled state of the control to the enabled state of the action
         action
             .enabled
             .bind(to: self.isEnabled)
-            .addDisposableTo(self.base.actionDisposeBag)
+            .disposed(by: self.base.actionDisposeBag)
     }
 
     /// Unbinds any existing action, disposing of all subscriptions.

--- a/Tests/ActionTests/ActionTests.swift
+++ b/Tests/ActionTests/ActionTests.swift
@@ -35,35 +35,35 @@ class ActionTests: QuickSpec {
             func bindAction(action: Action<String, String>) {
                 action.inputs
                     .bind(to: inputs)
-                    .addDisposableTo(disposeBag)
+                    .disposed(by: disposeBag)
 
                 action.elements
                     .bind(to: elements)
-                    .addDisposableTo(disposeBag)
+                    .disposed(by: disposeBag)
 
                 action.errors
                     .bind(to: errors)
-                    .addDisposableTo(disposeBag)
+                    .disposed(by: disposeBag)
                 
                 action.enabled
                     .bind(to: enabled)
-                    .addDisposableTo(disposeBag)
+                    .disposed(by: disposeBag)
                 
                 action.executing
                     .bind(to: executing)
-                    .addDisposableTo(disposeBag)
+                    .disposed(by: disposeBag)
 
                 action.executionObservables
                     .bind(to: executionObservables)
-                    .addDisposableTo(disposeBag)
+                    .disposed(by: disposeBag)
 
                 // Dummy subscription for multiple subcription tests
-                action.inputs.subscribe().addDisposableTo(disposeBag)
-                action.elements.subscribe().addDisposableTo(disposeBag)
-                action.errors.subscribe().addDisposableTo(disposeBag)
-                action.enabled.subscribe().addDisposableTo(disposeBag)
-                action.executing.subscribe().addDisposableTo(disposeBag)
-                action.executionObservables.subscribe().addDisposableTo(disposeBag)
+                action.inputs.subscribe().disposed(by: disposeBag)
+                action.elements.subscribe().disposed(by: disposeBag)
+                action.errors.subscribe().disposed(by: disposeBag)
+                action.enabled.subscribe().disposed(by: disposeBag)
+                action.executing.subscribe().disposed(by: disposeBag)
+                action.executionObservables.subscribe().disposed(by: disposeBag)
             }
 
             describe("single element action") {
@@ -377,18 +377,18 @@ class ActionTests: QuickSpec {
             func bindAndExecuteTwice(action: Action<String, String>) {
                 action.executionObservables
                     .bind(to: executionObservables)
-                    .addDisposableTo(disposeBag)
+                    .disposed(by: disposeBag)
                 
                 scheduler.scheduleAt(10) {
                     action.execute("a")
                         .bind(to: element)
-                        .addDisposableTo(disposeBag)
+                        .disposed(by: disposeBag)
                 }
 
                 scheduler.scheduleAt(20) {
                     action.execute("b")
                         .bind(to: element)
-                        .addDisposableTo(disposeBag)
+                        .disposed(by: disposeBag)
                 }
 
                 scheduler.start()
@@ -485,18 +485,18 @@ class ActionTests: QuickSpec {
                     
                     action.executionObservables
                         .bind(to: executionObservables)
-                        .addDisposableTo(disposeBag)
+                        .disposed(by: disposeBag)
                     
                     scheduler.scheduleAt(10) {
                         action.execute("a")
                             .bind(to: element)
-                            .addDisposableTo(disposeBag)
+                            .disposed(by: disposeBag)
                     }
 
                     scheduler.scheduleAt(20) {
                         action.execute("b")
                             .bind(to: secondElement)
-                            .addDisposableTo(disposeBag)
+                            .disposed(by: disposeBag)
                     }
 
                     scheduler.scheduleAt(30) {

--- a/Tests/ActionTests/AlertActionTests.swift
+++ b/Tests/ActionTests/AlertActionTests.swift
@@ -52,7 +52,7 @@ class AlertActionTests: QuickSpec {
                     .subscribe(onNext: { _ in
                         done()
                     })
-                    .addDisposableTo(disposeBag)
+                    .disposed(by: disposeBag)
             }
 
             expect(subject.isEnabled) == false
@@ -73,7 +73,7 @@ class AlertActionTests: QuickSpec {
                     .subscribe(onNext: nil, onError: nil, onCompleted: nil, onDisposed: {
                         disposed = true
                     })
-                    .addDisposableTo(disposeBag)
+                    .disposed(by: disposeBag)
             }
             
             subject.rx.action = nil

--- a/Tests/ActionTests/BarButtonTests.swift
+++ b/Tests/ActionTests/BarButtonTests.swift
@@ -97,7 +97,7 @@ class BarButtonTests: QuickSpec {
 					.subscribe(onNext: nil, onError: nil, onCompleted: nil, onDisposed: {
 						disposed = true
 					})
-					.addDisposableTo(disposeBag)
+					.disposed(by: disposeBag)
 			}
 			
 			subject.rx.action = nil

--- a/Tests/ActionTests/ButtonTests.swift
+++ b/Tests/ActionTests/ButtonTests.swift
@@ -98,7 +98,7 @@ class ButtonTests: QuickSpec {
                     .subscribe(onNext: nil, onError: nil, onCompleted: nil, onDisposed: {
                         disposed = true
                     })
-                    .addDisposableTo(disposeBag)
+                    .disposed(by: disposeBag)
             }
 
             subject.rx.action = nil


### PR DESCRIPTION
`addDisposableTo()` method should be deprecated in the future. I modified it to the recommended method `disposed(by:)` .
https://github.com/ReactiveX/RxSwift/blob/master/RxSwift/Deprecated.swift#L46