### PR TITLE
Fix missing watchOS target compile sources

### DIFF
--- a/Action.xcodeproj/project.pbxproj
+++ b/Action.xcodeproj/project.pbxproj
@@ -62,6 +62,9 @@
 		CA2861CA1ED6A41700BB327A /* InputSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2861C91ED6A41700BB327A /* InputSubjectTests.swift */; };
 		CA2861CB1ED6B08300BB327A /* InputSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2861C71ED6979400BB327A /* InputSubject.swift */; };
 		CA2861CC1ED6B08400BB327A /* InputSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2861C71ED6979400BB327A /* InputSubject.swift */; };
+		FA3F973C1EDAF46F00A84787 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E21DE28587007E1D0D /* Action.swift */; };
+		FA3F973D1EDAF46F00A84787 /* Action+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E01DE28587007E1D0D /* Action+Internal.swift */; };
+		FA3F973E1EDAF46F00A84787 /* InputSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2861C71ED6979400BB327A /* InputSubject.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -591,6 +594,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA3F973C1EDAF46F00A84787 /* Action.swift in Sources */,
+				FA3F973D1EDAF46F00A84787 /* Action+Internal.swift in Sources */,
+				FA3F973E1EDAF46F00A84787 /* InputSubject.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Current master
 --------------
 
 - Replace `PublishSubject` with `InputSubject` [#92](https://github.com/RxSwiftCommunity/Action/pull/92)
+- Added missing sources for watchOS target [#95](https://github.com/RxSwiftCommunity/Action/pull/95)
 
 3.0.0
 -----


### PR DESCRIPTION
Missing sources in the target of watchOS.
I think that can not use Carthage etc, so I fixed it.

## Before
<img width="400" alt="2017-05-28 21 07 10" src="https://cloud.githubusercontent.com/assets/2995438/26528590/81667608-43ea-11e7-8a99-642a88e1f162.png">

## After
<img width="400" alt="2017-05-28 21 06 47" src="https://cloud.githubusercontent.com/assets/2995438/26528595/8a3ab118-43ea-11e7-946c-6408936e8969.png">

