### PR TITLE
Version bump to 3.1.0

### DIFF
--- a/Action.podspec
+++ b/Action.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Action"
-  s.version      = "3.0.0"
+  s.version      = "3.1.0"
   s.summary      = "Abstracts actions to be performed in RxSwift."
   s.description  = <<-DESC
     Encapsulates an action to be performed, usually by a UIButton press.

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ Changelog
 Current master
 --------------
 
+3.1.0
+-----
+
 - Replace `PublishSubject` with `InputSubject` [#92](https://github.com/RxSwiftCommunity/Action/pull/92)
 - Added missing sources for watchOS target [#95](https://github.com/RxSwiftCommunity/Action/pull/95)
 


### PR DESCRIPTION
Since a relatively important change was made (changing PublishSubject to the new InputSubject by @Econa77) , I felt like this calls for a new version. 

I believe I don’t have permissions to push this up to CocoaPods, so would probably need your help here @ashfurrow 