### PR TITLE
RxSwift 4.0.0-rc0

### DIFF
--- a/Action.podspec
+++ b/Action.podspec
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/**/*.{swift}"
 
   s.frameworks  = "Foundation"
-  s.dependency "RxSwift", "~> 4.0.0-alpha.1"
-  s.dependency "RxCocoa", "~> 4.0.0-alpha.1"
+  s.dependency "RxSwift", "~> 4.0.0-rc.0"
+  s.dependency "RxCocoa", "~> 4.0.0-rc.0"
 
   s.watchos.exclude_files = "Control+Action.swift", "Button+Action.swift", "UIBarButtonItem+Action.swift", "UIAlertAction+Action.swift"
   s.osx.exclude_files = "UIBarButtonItem+Action.swift", "UIAlertAction+Action.swift"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "4.0.0-alpha.1"
+github "ReactiveX/RxSwift" "4.0.0-rc.0"

--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -71,7 +71,7 @@ public final class Action<Input, Element> {
                 if enabled {
                     return Observable.of(workFactory(input)
                                              .do(onError: { errorsSubject.onNext(.underlyingError($0)) })
-                                             .shareReplay(1))
+                                             .share(replay: 1, scope: .forever))
                 } else {
                     errorsSubject.onNext(.notEnabled)
                     return Observable.empty()
@@ -93,7 +93,7 @@ public final class Action<Input, Element> {
                                           Observable.just(false)])
             }
             .startWith(false)
-            .shareReplay(1)
+            .share(replay: 1, scope: .forever)
 
         Observable
             .combineLatest(executing, enabledIf) { !$0 && $1 }


### PR DESCRIPTION
- Updates for RxSwift release candidate `rc-0`
- change `shareReplay(1)` to use the new API `share(replay: 1, scope: .forever)` 