### PR TITLE
Action compatible for RxSwift/Cocoa 4.0.0

### DIFF
--- a/Action.podspec
+++ b/Action.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Action"
-  s.version      = "3.3.0-alpha.1"
+  s.version      = "4.0.0"
   s.summary      = "Abstracts actions to be performed in RxSwift."
   s.description  = <<-DESC
     Encapsulates an action to be performed, usually by a button press, but also useful to pass actions to execute later
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/**/*.{swift}"
 
   s.frameworks  = "Foundation"
-  s.dependency "RxSwift", "~> 4.0.0-rc.0"
-  s.dependency "RxCocoa", "~> 4.0.0-rc.0"
+  s.dependency "RxSwift", "~> 4.0.0"
+  s.dependency "RxCocoa", "~> 4.0.0"
 
   s.watchos.exclude_files = "Control+Action.swift", "Button+Action.swift", "UIBarButtonItem+Action.swift", "UIAlertAction+Action.swift"
   s.osx.exclude_files = "UIBarButtonItem+Action.swift", "UIAlertAction+Action.swift"


### PR DESCRIPTION
Currently are :
s.dependency "RxSwift", "4.0.0-rc.0"
s.dependency "RxCocoa", "4.0.0-rc.0"