### PR TITLE
Release version `3.4.0`

### DIFF
--- a/Action.podspec
+++ b/Action.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Action"
-  s.version      = "3.3.0-alpha.1"
+  s.version      = "3.4.0"
   s.summary      = "Abstracts actions to be performed in RxSwift."
   s.description  = <<-DESC
     Encapsulates an action to be performed, usually by a button press, but also useful to pass actions to execute later
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/**/*.{swift}"
 
   s.frameworks  = "Foundation"
-  s.dependency "RxSwift", "~> 4.0.0"
-  s.dependency "RxCocoa", "~> 4.0.0"
+  s.dependency "RxSwift", "~> 4.0"
+  s.dependency "RxCocoa", "~> 4.0"
 
   s.watchos.exclude_files = "Control+Action.swift", "Button+Action.swift", "UIBarButtonItem+Action.swift", "UIAlertAction+Action.swift"
   s.osx.exclude_files = "UIBarButtonItem+Action.swift", "UIAlertAction+Action.swift"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "4.0.0"
+github "ReactiveX/RxSwift" ~> 4.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,22 @@ Changelog
 Current master
 --------------
 
+3.4.0
+-----
+- Added full support for Swift 4.0
+- Added full support for RxSwift 4.0.0
+- Preserved old behavior for `shareReplay(1)` api changes from `RxSwift`. [#110](https://github.com/RxSwiftCommunity/Action/pull/110)
+
+
+Version table
+-------------
+
+| Swift version | RxSwift version | Action version |
+| ------------- | --------------- | -------------- |
+| Swift 3.0     | v3.2.*   	      | v2.2.0 		   |
+| Swift 3.2     | v3.6.*   	      | v3.2.0 		   |
+| **Swift 4**   | **v4.0.0**      | **v3.4.0**     |
+
 3.2.0
 -----
 - Add macOS bindings for NSControl and NSButton


### PR DESCRIPTION
- [x] Added change log description for release
- [x] Updated `Action.podspec` version number to match release version from `3.3.0-alpha.1` to `3.4.0` as discussed in issue #115 