### PR TITLE
Allow work factories with other return types than `Observable`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@ Changelog
 
 Current master
 --------------
+- Add convenience initializer with work factories returning `PrimitiveSequence` or any other `ObservableConvertibleType` [#125](https://github.com/RxSwiftCommunity/Action/pull/125)
+- Introduce `CompletableAction`, a typealias for action that only completes without emitting any elements [#125](https://github.com/RxSwiftCommunity/Action/pull/125)
 
 3.4.0
 -----

--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -4,6 +4,8 @@ import RxCocoa
 
 /// Typealias for compatibility with UIButton's rx.action property.
 public typealias CocoaAction = Action<Void, Void>
+/// Typealias for actions with work factory returns `Completable`.
+public typealias CompletableAction<Input> = Action<Input, Never>
 
 /// Possible errors from invoking execute()
 public enum ActionError: Error {


### PR DESCRIPTION
This PR closes #123 
- Adds convenience initialiser that takes a work factory returning `ObservableConvertibleType`. This allows constructing Actions with work factory returning;
   - `PrimitiveSequence` such as `Single`, `Completable`, etc.
   - `SharedSequence` such as `Driver`
- Adds type alias `CompletableAction`.
   - An action with a work factory returning a `Completable`
   - Its `elements` will emit no next events