### PR TITLE
[Fix][Carthage] Remove Submodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,0 @@
-[submodule "Carthage/Checkouts/RxSwift"]
-	path = Carthage/Checkouts/RxSwift
-	url = https://github.com/ReactiveX/RxSwift.git
-[submodule "Carthage/Checkouts/Quick"]
-	path = Carthage/Checkouts/Quick
-	url = https://github.com/Quick/Quick.git
-[submodule "Carthage/Checkouts/Nimble"]
-	path = Carthage/Checkouts/Nimble
-	url = https://github.com/Quick/Nimble.git


### PR DESCRIPTION
Hello, 

Since the commit b49959c646fcac567a4b0cfe87dad7b14b343300, this is not working for carthage anymore.

I got the error: "Parse error: expected submodule commit SHA in output of task (ls-tree -z 9c413d35c3b0f14dd2a817c866415afd9a40e4db Carthage/Checkouts/RxSwift) but encountered: "

After some research, apparently, it's because the submodules have been removed.
https://github.com/Carthage/Carthage/issues/135

So, removing the .gitmodules file should do the job.


