### PR TITLE
Flatten error by removing ActionError

### DIFF
--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -8,9 +8,13 @@ public typealias CocoaAction = Action<Void, Void>
 public typealias CompletableAction<Input> = Action<Input, Never>
 
 /// Possible errors from invoking execute()
-public enum ActionError: Error {
-    case notEnabled
-    case underlyingError(Error)
+public struct ActionDisabledError: LocalizedError {
+    /// A localized message describing what error occurred.
+    public var errorDescription: String?
+    
+    public init() {
+        errorDescription = NSLocalizedString("Action not enabled. Please make sure your workFactory Observable send onCompleted!", comment: "")
+    }
 }
 
 /**
@@ -33,7 +37,11 @@ public final class Action<Input, Element> {
 
     /// Errors aggrevated from invocations of execute().
     /// Delivered on whatever scheduler they were sent from.
-    public let errors: Observable<ActionError>
+    public let errors: Observable<Error>
+    
+    /// Errors when Action cannot execute due to disabled.
+    /// Delivered on whatever scheduler they were sent from.
+    public let disabledErrors: Observable<ActionDisabledError>
 
     /// Whether or not we're currently executing.
     /// Delivered on whatever scheduler they were sent from.
@@ -73,18 +81,21 @@ public final class Action<Input, Element> {
         let enabledSubject = BehaviorSubject<Bool>(value: false)
         enabled = enabledSubject.asObservable()
 
-        let errorsSubject = PublishSubject<ActionError>()
+        let errorsSubject = PublishSubject<Error>()
         errors = errorsSubject.asObservable()
+        
+        let disabledErrorSubject = PublishSubject<ActionDisabledError>()
+        disabledErrors = disabledErrorSubject.asObservable()
 
         executionObservables = inputs
             .withLatestFrom(enabled) { input, enabled in (input, enabled) }
             .flatMap { input, enabled -> Observable<Observable<Element>> in
                 if enabled {
                     return Observable.of(workFactory(input)
-                                             .do(onError: { errorsSubject.onNext(.underlyingError($0)) })
-                                             .share(replay: 1, scope: .forever))
+                        .do(onError: { errorsSubject.onNext($0) })
+                        .share(replay: 1, scope: .forever))
                 } else {
-                    errorsSubject.onNext(.notEnabled)
+                    disabledErrorSubject.onNext(ActionDisabledError())
                     return Observable.empty()
                 }
             }
@@ -119,14 +130,12 @@ public final class Action<Input, Element> {
         }
 
 		let subject = ReplaySubject<Element>.createUnbounded()
+        let rawDisabledErrors = disabledErrors.map { $0 as Error }
+        
+        let error = Observable.merge(errors, rawDisabledErrors).map { Observable<Element>.error($0) }
 
-		let work = executionObservables
-			.map { $0.catchError { throw ActionError.underlyingError($0) } }
-
-		let error = errors
-			.map { Observable<Element>.error($0) }
-
-		work.amb(error)
+        executionObservables
+            .amb(error)
 			.take(1)
 			.flatMap { $0 }
 			.subscribe(subject)

--- a/Tests/ActionTests/ActionTests.swift
+++ b/Tests/ActionTests/ActionTests.swift
@@ -9,7 +9,10 @@ class ActionTests: QuickSpec {
 	override func spec() {
 		var scheduler: TestScheduler!
 		var disposeBag: DisposeBag!
-		
+        
+        let testError: NSError = NSError(domain: "TestError", code: -101)
+		let testDisabledError = ActionDisabledError()
+        
 		beforeEach {
 			scheduler = TestScheduler(initialClock: 0)
 			disposeBag = DisposeBag()
@@ -46,7 +49,8 @@ class ActionTests: QuickSpec {
 		describe("action properties") {
 			var inputs: TestableObserver<String>!
 			var elements: TestableObserver<String>!
-			var errors: TestableObserver<ActionError>!
+			var errors: TestableObserver<Error>!
+            var disabledErrors: TestableObserver<ActionDisabledError>!
 			var enabled: TestableObserver<Bool>!
 			var executing: TestableObserver<Bool>!
 			var executionObservables: TestableObserver<Observable<String>>!
@@ -54,7 +58,8 @@ class ActionTests: QuickSpec {
 			beforeEach {
 				inputs = scheduler.createObserver(String.self)
 				elements = scheduler.createObserver(String.self)
-				errors = scheduler.createObserver(ActionError.self)
+				errors = scheduler.createObserver(Error.self)
+                disabledErrors = scheduler.createObserver(ActionDisabledError.self)
 				enabled = scheduler.createObserver(Bool.self)
 				executing = scheduler.createObserver(Bool.self)
 				executionObservables = scheduler.createObserver(Observable<String>.self)
@@ -72,7 +77,11 @@ class ActionTests: QuickSpec {
 				action.errors
 					.bind(to: errors)
 					.disposed(by: disposeBag)
-				
+                
+                action.disabledErrors
+                    .bind(to: disabledErrors)
+                    .disposed(by: disposeBag)
+
 				action.enabled
 					.bind(to: enabled)
 					.disposed(by: disposeBag)
@@ -111,8 +120,12 @@ class ActionTests: QuickSpec {
 					}
 					
 					it("errors observable receives nothing") {
-						XCTAssertEqual(errors.events, [])
+						XCTAssertTrue(errors.events.isEmpty)
 					}
+                    
+                    it("disabledErrors observable receives nothing") {
+                        XCTAssertTrue(disabledErrors.events.isEmpty)
+                    }
 					
 					it("disabled until element returns") {
 						XCTAssertEqual(enabled.events, [
@@ -187,10 +200,14 @@ class ActionTests: QuickSpec {
 							])
 					}
 					
-					it("errors observable receives nothing") {
-						XCTAssertEqual(errors.events, [])
-					}
-					
+                    it("errors observable receives nothing") {
+                        XCTAssertTrue(errors.events.isEmpty)
+                    }
+                    
+                    it("disabledErrors observable receives nothing") {
+                        XCTAssertTrue(disabledErrors.events.isEmpty)
+                    }
+                    
 					it("disabled until element returns") {
 						XCTAssertEqual(enabled.events, [
 							next(0, true),
@@ -267,11 +284,12 @@ class ActionTests: QuickSpec {
 					}
 					
 					it("errors observable receives generated errors") {
-						XCTAssertEqual(errors.events, [
-							next(10, .underlyingError(TestError)),
-							next(20, .underlyingError(TestError)),
-							])
+                        XCTAssertEqual(errors.events.map { $0.value.element! as NSError }, [testError, testError])
 					}
+                    
+                    it("disabledErrors observable receives nothing") {
+                        XCTAssertTrue(disabledErrors.events.isEmpty)
+                    }
 					
 					it("disabled until error returns") {
 						XCTAssertEqual(enabled.events, [
@@ -301,7 +319,7 @@ class ActionTests: QuickSpec {
 				var action: Action<String, String>!
 				
 				beforeEach {
-					action = Action { _ in Observable.error(TestError) }
+					action = Action { _ in Observable.error(testError) }
 					bindAction(action: action)
 				}
 				
@@ -339,11 +357,12 @@ class ActionTests: QuickSpec {
 						XCTAssertEqual(elements.events, [])
 					}
 					
-					it("errors observable receives generated errors") {
-						XCTAssertEqual(errors.events, [
-							next(10, .notEnabled),
-							next(20, .notEnabled),
-							])
+                    it("errors observable receives nothing") {
+                        XCTAssertTrue(errors.events.isEmpty)
+                    }
+                    
+					it("disabledErrors observable receives notEnable errors") {
+                        XCTAssertEqual(disabledErrors.events.map { $0.value.element! as ActionDisabledError }, [testDisabledError, testDisabledError])
 					}
 					
 					it("disabled") {
@@ -468,17 +487,17 @@ class ActionTests: QuickSpec {
 			
 			context("error action") {
 				beforeEach {
-					action = Action { _ in Observable.error(TestError) }
+					action = Action { _ in Observable.error(testError) }
 					bindAndExecuteTwice(action: action)
 				}
 				
-				it("element fails with underlyingError") {
-					XCTAssertEqual(element.events, [
-						error(10, ActionError.underlyingError(TestError)),
-						error(20, ActionError.underlyingError(TestError)),
-						])
-				}
-				
+                it("element fails with generated error") {
+                    XCTAssertEqual(element.events, [
+                        error(10, testError),
+                        error(20, testError),
+                        ])
+                }
+                
 				it("executes twice") {
 					expect(executionObservables.events.count) == 2
 				}
@@ -492,8 +511,8 @@ class ActionTests: QuickSpec {
 				
 				it("element fails with notEnabled") {
 					XCTAssertEqual(element.events, [
-						error(10, ActionError.notEnabled),
-						error(20, ActionError.notEnabled),
+						error(10, testDisabledError),
+						error(20, testDisabledError),
 						])
 				}
 				
@@ -547,7 +566,7 @@ class ActionTests: QuickSpec {
 				
 				it("second element fails with notEnabled error") {
 					XCTAssertEqual(secondElement.events, [
-						error(20, ActionError.notEnabled)
+						error(20, testDisabledError)
 						])
 				}
 				
@@ -559,19 +578,8 @@ class ActionTests: QuickSpec {
 	}
 }
 
-extension ActionError: Equatable {
-	// Not accurate but convenient for testing.
-	public static func ==(lhs: ActionError, rhs: ActionError) -> Bool {
-		switch (lhs, rhs) {
-		case (.notEnabled, .notEnabled):
-			return true
-		case (.underlyingError, .underlyingError):
-			return true
-		default:
-			return false
-		}
-	}
+extension ActionDisabledError: Equatable {
+    public static func ==(lhs: ActionDisabledError, rhs: ActionDisabledError) -> Bool {
+        return lhs.errorDescription == rhs.errorDescription
+    }
 }
-
-extension String: Error { }
-let TestError = "Test Error"

--- a/Tests/InputSubjectTests.swift
+++ b/Tests/InputSubjectTests.swift
@@ -8,7 +8,8 @@ class InputSubjectTests: QuickSpec {
     override func spec() {
         var scheduler: TestScheduler!
         var disposeBag: DisposeBag!
-
+        let testError: NSError = NSError(domain: "TestError", code: -101)
+        
         beforeEach {
             scheduler = TestScheduler(initialClock: 0)
             disposeBag = DisposeBag()
@@ -47,7 +48,7 @@ class InputSubjectTests: QuickSpec {
                 scheduler.scheduleAt(10) { subject.onNext(1) }
                 scheduler.scheduleAt(20) { subject.onNext(2) }
                 scheduler.scheduleAt(30) { subject.onNext(3) }
-                scheduler.start()
+                    scheduler.start()
 
                 XCTAssertEqual(observer.events, [
                     next(10, 1),
@@ -55,15 +56,16 @@ class InputSubjectTests: QuickSpec {
                     next(30, 3)
                 ])
             }
-
             it("ignore .error events") {
                 let subject = InputSubject<Int>()
                 let observer = scheduler.createObserver(Int.self)
+                
                 subject.asObservable()
                     .bind(to: observer)
                     .disposed(by: disposeBag)
+                
                 scheduler.scheduleAt(10) { subject.onNext(1) }
-                scheduler.scheduleAt(20) { subject.onError(TestError) }
+                scheduler.scheduleAt(20) { subject.onError(testError) }
                 scheduler.scheduleAt(30) { subject.onNext(3) }
                 scheduler.start()
 


### PR DESCRIPTION
I really sorry for a long time not active. This replaces PR for #138 and will resolve #119 (original by @bobgodwinx )

After referring Action's implementation from ReactiveSwift, I decide to add `disabledErrors: Observable<Error>` and remove `ActionError`. This will make breaking change but will help end users avoid misunderstand between `.errors/.underlyingErrors` and `.executionErrors` from the original proposal. I add `ActionDisabledError` for better debugging.

What do you think @bobgodwinx

