### PR TITLE
Less restrictive dependency definitions

### DIFF
--- a/Action.podspec
+++ b/Action.podspec
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/**/*.{swift}"
 
   s.frameworks  = "Foundation"
-  s.dependency "RxSwift", "~> 4.3.0"
-  s.dependency "RxCocoa", "~> 4.3.0"
+  s.dependency "RxSwift", "~> 4.3"
+  s.dependency "RxCocoa", "~> 4.3"
 
   s.watchos.exclude_files = "Control+Action.swift", "Button+Action.swift", "UIBarButtonItem+Action.swift", "UIAlertAction+Action.swift"
   s.osx.exclude_files = "UIBarButtonItem+Action.swift", "UIAlertAction+Action.swift"

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,8 +4,7 @@ Changelog
 
 Current master
 --------------
-
-- Nothing yet!
+- Less restrictive RxSwift/RxCocoa dependencies in podspec, now supporting RxSwift/RxCocoa 4.x starting with version 4.3
 
 3.9.0
 -----


### PR DESCRIPTION
RxSwift, RxCocoa are defined too strict, Action no longer works with RxSwift, RxCocoa 4.4 because of this.