### PR TITLE
Syntax sugar to execute when Input is Void.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ Changelog
 Current master
 --------------
 
-- Nothing yet!
+- Adding syntax sugar `execute()` method on `Action` when `Input` is `Void`. [#171](https://github.com/RxSwiftCommunity/Action/pull/171)
 
 3.9.1
 -----

--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -135,3 +135,10 @@ public final class Action<Input, Element> {
 		return subject.asObservable()
     }
 }
+
+extension Action where Input == Void {
+    @discardableResult
+    public func execute() -> Observable<Element> {
+        return execute(())
+    }
+}

--- a/Sources/Action/UIKitExtensions/UIAlertAction+Action.swift
+++ b/Sources/Action/UIKitExtensions/UIAlertAction+Action.swift
@@ -13,7 +13,7 @@ public extension UIAlertAction {
     
     public static func Action(_ title: String?, style: ActionStyle) -> UIAlertAction {
         return UIAlertAction(title: title, style: style, handler: { action in
-            action.rx.action?.execute(())
+            action.rx.action?.execute()
             return
         })
     }

--- a/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
+++ b/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
@@ -31,7 +31,7 @@ public extension Reactive where Base: UIBarButtonItem {
                     .disposed(by: self.base.actionDisposeBag)
                 
                 self.tap.subscribe(onNext: {
-                    action.execute(())
+                    action.execute()
                 })
                 .disposed(by: self.base.actionDisposeBag)
             }


### PR DESCRIPTION
Hey guys :))
This is a simple syntax sugar when Input is Void, so we can call `execute()` instead of always `execute(())` with the (). 
 