### PR TITLE
Update WatchOS minimum deployment target to 3.0

### DIFF
--- a/Action.podspec
+++ b/Action.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
-  s.watchos.deployment_target = '2.0'
+  s.watchos.deployment_target = '3.0'
   s.tvos.deployment_target = '9.0'
 
   s.source       = { :git => "https://github.com/RxSwiftCommunity/Action.git", :tag => s.version.to_s }


### PR DESCRIPTION
This is required since RxSwift raised minimum deployment target to WatchOS 3.0 as discussed in #173