### PR TITLE
Extracting Errors

### DIFF
--- a/Action.podspec
+++ b/Action.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Action"
-  s.version      = "3.10.2"
+  s.version      = "3.11.0"
   s.summary      = "Abstracts actions to be performed in RxSwift."
   s.description  = <<-DESC
     Encapsulates an action to be performed, usually by a button press, but also useful to pass actions to execute later

--- a/Action.xcodeproj/project.pbxproj
+++ b/Action.xcodeproj/project.pbxproj
@@ -68,6 +68,9 @@
 		C41CE73D22283CF90006E722 /* RxAtomic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41CE72522283BEE0006E722 /* RxAtomic.framework */; };
 		C41CE74022283D220006E722 /* RxAtomic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41CE73E22283D220006E722 /* RxAtomic.framework */; };
 		C41CE74122283D220006E722 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41CE73F22283D220006E722 /* RxSwift.framework */; };
+		C41E08EE2237D26D0039D213 /* Action+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DE00042229758700FB50AB /* Action+Extensions.swift */; };
+		C41E08EF2237D2700039D213 /* Action+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DE00042229758700FB50AB /* Action+Extensions.swift */; };
+		C41E08F02237D2740039D213 /* Action+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DE00042229758700FB50AB /* Action+Extensions.swift */; };
 		C4DE00052229758700FB50AB /* Action+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DE00042229758700FB50AB /* Action+Extensions.swift */; };
 		CA2861C81ED6979400BB327A /* InputSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2861C71ED6979400BB327A /* InputSubject.swift */; };
 		CA2861CA1ED6A41700BB327A /* InputSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2861C91ED6A41700BB327A /* InputSubjectTests.swift */; };
@@ -711,6 +714,7 @@
 				1FCDDA651EAC31EF006EB95B /* Action+Internal.swift in Sources */,
 				7B4BFE5420C12B7800D72FB0 /* UIRefreshControl+Action.swift in Sources */,
 				1FCDDA661EAC31EF006EB95B /* UIAlertAction+Action.swift in Sources */,
+				C41E08EE2237D26D0039D213 /* Action+Extensions.swift in Sources */,
 				3D730DEA1F674043008534D3 /* Button+Action.swift in Sources */,
 				1FCDDA671EAC31EF006EB95B /* UIBarButtonItem+Action.swift in Sources */,
 				CA2861CB1ED6B08300BB327A /* InputSubject.swift in Sources */,
@@ -723,6 +727,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CA2861CC1ED6B08400BB327A /* InputSubject.swift in Sources */,
+				C41E08EF2237D2700039D213 /* Action+Extensions.swift in Sources */,
 				3D730DE51F673C65008534D3 /* Control+Action.swift in Sources */,
 				1FCDDA8A1EAC329E006EB95B /* Action.swift in Sources */,
 				3D730DEB1F674044008534D3 /* Button+Action.swift in Sources */,
@@ -737,6 +742,7 @@
 				FA3F973C1EDAF46F00A84787 /* Action.swift in Sources */,
 				FA3F973D1EDAF46F00A84787 /* Action+Internal.swift in Sources */,
 				FA3F973E1EDAF46F00A84787 /* InputSubject.swift in Sources */,
+				C41E08F02237D2740039D213 /* Action+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Action.xcodeproj/project.pbxproj
+++ b/Action.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		C41CE73D22283CF90006E722 /* RxAtomic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41CE72522283BEE0006E722 /* RxAtomic.framework */; };
 		C41CE74022283D220006E722 /* RxAtomic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41CE73E22283D220006E722 /* RxAtomic.framework */; };
 		C41CE74122283D220006E722 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41CE73F22283D220006E722 /* RxSwift.framework */; };
+		C4DE00052229758700FB50AB /* Action+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DE00042229758700FB50AB /* Action+Extensions.swift */; };
 		CA2861C81ED6979400BB327A /* InputSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2861C71ED6979400BB327A /* InputSubject.swift */; };
 		CA2861CA1ED6A41700BB327A /* InputSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2861C91ED6A41700BB327A /* InputSubjectTests.swift */; };
 		CA2861CB1ED6B08300BB327A /* InputSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2861C71ED6979400BB327A /* InputSubject.swift */; };
@@ -155,6 +156,7 @@
 		C41CE73922283CD00006E722 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/tvOS/RxSwift.framework; sourceTree = "<group>"; };
 		C41CE73E22283D220006E722 /* RxAtomic.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxAtomic.framework; path = Carthage/Build/watchOS/RxAtomic.framework; sourceTree = "<group>"; };
 		C41CE73F22283D220006E722 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/watchOS/RxSwift.framework; sourceTree = "<group>"; };
+		C4DE00042229758700FB50AB /* Action+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Action+Extensions.swift"; sourceTree = "<group>"; };
 		C4E0263F20D119EE00C8164C /* Action.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Action.podspec; sourceTree = "<group>"; };
 		C4E0264020D11A0F00C8164C /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		C4E0264120D11A0F00C8164C /* Cartfile.private */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.private; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 			isa = PBXGroup;
 			children = (
 				7F0569E21DE28587007E1D0D /* Action.swift */,
+				C4DE00042229758700FB50AB /* Action+Extensions.swift */,
 				7F0569E01DE28587007E1D0D /* Action+Internal.swift */,
 				CA2861C71ED6979400BB327A /* InputSubject.swift */,
 				3D730DE11F673BCB008534D3 /* CommonUI */,
@@ -779,6 +782,7 @@
 				7F0569E81DE28587007E1D0D /* Action+Internal.swift in Sources */,
 				7B4BFE5520C12B7800D72FB0 /* UIRefreshControl+Action.swift in Sources */,
 				7F0569ED1DE28587007E1D0D /* UIBarButtonItem+Action.swift in Sources */,
+				C4DE00052229758700FB50AB /* Action+Extensions.swift in Sources */,
 				3D730DE91F673FD9008534D3 /* Button+Action.swift in Sources */,
 				CA2861C81ED6979400BB327A /* InputSubject.swift in Sources */,
 				3D730DE31F673BE4008534D3 /* Control+Action.swift in Sources */,

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ Current master
 --------------
 3.11.0
 -------
-- Introduction of  `underlyingError`  observable which returns a `Swift.Error`  element type. 
+- Introduction of  `underlyingError` observable which returns a `Swift.Error`  element type. 
 - Updated specs that were breaking in `Circle CI` pipeline 
 
 3.10.2

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ Changelog
 
 Current master
 --------------
+3.11.0
+-------
+- Introduction of  `underlyingError` streams 🔥 which returns a `Swift.Error` type. 
+- Updated specs that were breaking in `Circle CI` pipeline 
 
 3.10.2
 -------

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ Current master
 --------------
 3.11.0
 -------
-- Introduction of  `underlyingError` streams 🔥 which returns a `Swift.Error` type. 
+- Introduction of  `underlyingError`  observable which returns a `Swift.Error`  element type. 
 - Updated specs that were breaking in `Circle CI` pipeline 
 
 3.10.2

--- a/Sources/Action/Action+Extensions.swift
+++ b/Sources/Action/Action+Extensions.swift
@@ -21,3 +21,11 @@ extension Action {
         }
     }
 }
+
+extension Action where Input == Void {
+    /// use to trigger an action.
+    @discardableResult
+    public func execute() -> Observable<Element> {
+        return execute(())
+    }
+}

--- a/Sources/Action/Action+Extensions.swift
+++ b/Sources/Action/Action+Extensions.swift
@@ -1,15 +1,7 @@
-//
-//  Action+Extensions.swift
-//  Action
-//
-//  Created by Obi Bob on 01.03.19.
-//  Copyright © 2019 CezaryKopacz. All rights reserved.
-//
-
 import Foundation
 import RxSwift
 
-extension Action {
+public extension Action {
     /// Filters out `notEnabled` errors and returns
     /// only underlying error from `ActionError`
     public var underlyingError: Observable<Error> {
@@ -22,7 +14,7 @@ extension Action {
     }
 }
 
-extension Action where Input == Void {
+public extension Action where Input == Void {
     /// use to trigger an action.
     @discardableResult
     public func execute() -> Observable<Element> {

--- a/Sources/Action/Action+Extensions.swift
+++ b/Sources/Action/Action+Extensions.swift
@@ -7,3 +7,17 @@
 //
 
 import Foundation
+import RxSwift
+
+extension Action {
+    /// Filters out `notEnabled` errors and returns
+    /// only underlying error from `ActionError`
+    var underlyingError: Observable<Error?> {
+        return errors.map { actionError in
+            guard case .underlyingError(let error) = actionError else {
+                return nil
+            }
+            return error
+        }
+    }
+}

--- a/Sources/Action/Action+Extensions.swift
+++ b/Sources/Action/Action+Extensions.swift
@@ -12,12 +12,12 @@ import RxSwift
 extension Action {
     /// Filters out `notEnabled` errors and returns
     /// only underlying error from `ActionError`
-    var underlyingError: Observable<Error?> {
-        return errors.map { actionError in
+    var underlyingError: Observable<Error> {
+        return errors.flatMap { actionError -> Observable<Error> in
             guard case .underlyingError(let error) = actionError else {
-                return nil
+                return Observable.empty()
             }
-            return error
+            return Observable.just(error)
         }
     }
 }

--- a/Sources/Action/Action+Extensions.swift
+++ b/Sources/Action/Action+Extensions.swift
@@ -1,0 +1,9 @@
+//
+//  Action+Extensions.swift
+//  Action
+//
+//  Created by Obi Bob on 01.03.19.
+//  Copyright © 2019 CezaryKopacz. All rights reserved.
+//
+
+import Foundation

--- a/Sources/Action/Action+Extensions.swift
+++ b/Sources/Action/Action+Extensions.swift
@@ -12,7 +12,7 @@ import RxSwift
 extension Action {
     /// Filters out `notEnabled` errors and returns
     /// only underlying error from `ActionError`
-    var underlyingError: Observable<Error> {
+    public var underlyingError: Observable<Error> {
         return errors.flatMap { actionError -> Observable<Error> in
             guard case .underlyingError(let error) = actionError else {
                 return Observable.empty()

--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -135,10 +135,3 @@ public final class Action<Input, Element> {
 		return subject.asObservable()
     }
 }
-
-extension Action where Input == Void {
-    @discardableResult
-    public func execute() -> Observable<Element> {
-        return execute(())
-    }
-}

--- a/Tests/ActionTests/ActionTests.swift
+++ b/Tests/ActionTests/ActionTests.swift
@@ -91,13 +91,13 @@ class ActionTests: QuickSpec {
                     .bind(to: underlyingError)
                     .disposed(by: disposeBag)
 				
-				// Dummy subscription for multiple subcription tests
-				action.inputs.subscribe().disposed(by: disposeBag)
-				action.elements.subscribe().disposed(by: disposeBag)
-				action.errors.subscribe().disposed(by: disposeBag)
-				action.enabled.subscribe().disposed(by: disposeBag)
-				action.executing.subscribe().disposed(by: disposeBag)
-				action.executionObservables.subscribe().disposed(by: disposeBag)
+                // Dummy subscription for multiple subcription tests
+                action.inputs.subscribe().disposed(by: disposeBag)
+                action.elements.subscribe().disposed(by: disposeBag)
+                action.errors.subscribe().disposed(by: disposeBag)
+                action.enabled.subscribe().disposed(by: disposeBag)
+                action.executing.subscribe().disposed(by: disposeBag)
+                action.executionObservables.subscribe().disposed(by: disposeBag)
                 action.underlyingError.subscribe().disposed(by: disposeBag)
 			}
 			

--- a/Tests/ActionTests/ActionTests.swift
+++ b/Tests/ActionTests/ActionTests.swift
@@ -3,7 +3,7 @@ import Nimble
 import RxSwift
 import RxBlocking
 import RxTest
-import Action
+@testable import Action
 
 class ActionTests: QuickSpec {
 	override func spec() {
@@ -50,6 +50,7 @@ class ActionTests: QuickSpec {
 			var enabled: TestableObserver<Bool>!
 			var executing: TestableObserver<Bool>!
 			var executionObservables: TestableObserver<Observable<String>>!
+            var underlyingError: TestableObserver<Error>!
 			
 			beforeEach {
 				inputs = scheduler.createObserver(String.self)
@@ -58,6 +59,7 @@ class ActionTests: QuickSpec {
 				enabled = scheduler.createObserver(Bool.self)
 				executing = scheduler.createObserver(Bool.self)
 				executionObservables = scheduler.createObserver(Observable<String>.self)
+                underlyingError = scheduler.createObserver(Error.self)
 			}
 			
 			func bindAction(action: Action<String, String>) {
@@ -84,6 +86,10 @@ class ActionTests: QuickSpec {
 				action.executionObservables
 					.bind(to: executionObservables)
 					.disposed(by: disposeBag)
+                
+                action.underlyingError
+                    .bind(to: underlyingError)
+                    .disposed(by: disposeBag)
 				
 				// Dummy subscription for multiple subcription tests
 				action.inputs.subscribe().disposed(by: disposeBag)
@@ -92,6 +98,7 @@ class ActionTests: QuickSpec {
 				action.enabled.subscribe().disposed(by: disposeBag)
 				action.executing.subscribe().disposed(by: disposeBag)
 				action.executionObservables.subscribe().disposed(by: disposeBag)
+                action.underlyingError.subscribe().disposed(by: disposeBag)
 			}
 			
 			describe("single element action") {
@@ -267,11 +274,22 @@ class ActionTests: QuickSpec {
 					}
 					
 					it("errors observable receives generated errors") {
-						XCTAssertEqual(errors.events, [
+                        XCTAssertEqual(errors.events, [
 							next(10, .underlyingError(TestError)),
 							next(20, .underlyingError(TestError)),
 							])
 					}
+                    
+                    it("underlyingError observable receives 2 generated errors") {
+                        XCTAssertEqual(underlyingError.events.count, 2)
+                    }
+                    
+                    it("underlyingError observable receives generated errors") {
+                        let first = underlyingError.events[0].value.element as! String
+                        let second = underlyingError.events[1].value.element as! String
+                        XCTAssertEqual(first, TestError)
+                        XCTAssertEqual(second, TestError)
+                    }
 					
 					it("disabled until error returns") {
 						XCTAssertEqual(enabled.events, [
@@ -345,6 +363,10 @@ class ActionTests: QuickSpec {
 							next(20, .notEnabled),
 							])
 					}
+                    
+                    it("underlyingError observable receives zero generated errors") {
+                        XCTAssertEqual(underlyingError.events.count, 0)
+                    }
 					
 					it("disabled") {
 						XCTAssertEqual(enabled.events, [

--- a/Tests/ActionTests/ActionTests.swift
+++ b/Tests/ActionTests/ActionTests.swift
@@ -44,23 +44,23 @@ class ActionTests: QuickSpec {
         }
         
 		describe("action properties") {
-			var inputs: TestableObserver<String>!
-			var elements: TestableObserver<String>!
-			var errors: TestableObserver<ActionError>!
-			var enabled: TestableObserver<Bool>!
-			var executing: TestableObserver<Bool>!
-			var executionObservables: TestableObserver<Observable<String>>!
+            var inputs: TestableObserver<String>!
+            var elements: TestableObserver<String>!
+            var errors: TestableObserver<ActionError>!
+            var enabled: TestableObserver<Bool>!
+            var executing: TestableObserver<Bool>!
+            var executionObservables: TestableObserver<Observable<String>>!
             var underlyingError: TestableObserver<Error>!
-			
-			beforeEach {
-				inputs = scheduler.createObserver(String.self)
-				elements = scheduler.createObserver(String.self)
-				errors = scheduler.createObserver(ActionError.self)
-				enabled = scheduler.createObserver(Bool.self)
-				executing = scheduler.createObserver(Bool.self)
-				executionObservables = scheduler.createObserver(Observable<String>.self)
+            
+            beforeEach {
+                inputs = scheduler.createObserver(String.self)
+                elements = scheduler.createObserver(String.self)
+                errors = scheduler.createObserver(ActionError.self)
+                enabled = scheduler.createObserver(Bool.self)
+                executing = scheduler.createObserver(Bool.self)
+                executionObservables = scheduler.createObserver(Observable<String>.self)
                 underlyingError = scheduler.createObserver(Error.self)
-			}
+            }
 			
 			func bindAction(action: Action<String, String>) {
 				action.inputs

--- a/Tests/iOS-Tests/BindToTests.swift
+++ b/Tests/iOS-Tests/BindToTests.swift
@@ -39,7 +39,7 @@ class BindToTests: QuickSpec {
 			})
 			button.rx.bind(to: action, input: "Hi there!")
 			// Setting the action has an asynchronous effect of adding a target.
-			expect(button.allTargets).toEventuallyNot( beEmpty() )
+			expect(button.allTargets.count) == 1
 			
 			button.test_executeTap()
 			
@@ -55,7 +55,7 @@ class BindToTests: QuickSpec {
 			})
 			button.rx.bind(to: action, controlEvent: button.rx.tap, inputTransform: { input in "\(input)" })
 			// Setting the action has an asynchronous effect of adding a target.
-			expect(button.allTargets).toEventuallyNot( beEmpty() )
+			expect(button.allTargets.count) == 1
 			
 			button.test_executeTap()
 			
@@ -98,12 +98,12 @@ class BindToTests: QuickSpec {
 				})
 				button.rx.bind(to: action, input: "Hi there!")
 				// Setting the action has an asynchronous effect of adding a target.
-				expect(button.allTargets).toEventuallyNot( beEmpty() )
+				expect(button.allTargets.count) == 1
 				
 				button.rx.unbindAction()
 				button.test_executeTap()
 				
-				expect(button.allTargets).toEventually( beEmpty() )
+				expect(button.allTargets.count) == 0
 			}
             
             it("unbinds actions for UIRefreshControl") {
@@ -114,12 +114,12 @@ class BindToTests: QuickSpec {
                 })
                 refreshControl.rx.bind(to: action, input: "Hi there!")
                 // Setting the action has an asynchronous effect of adding a target.
-                expect(refreshControl.allTargets).toEventuallyNot( beEmpty() )
+                expect(refreshControl.allTargets.count) == 1
                 
                 refreshControl.rx.unbindAction()
                 refreshControl.test_executeRefresh()
                 
-                expect(refreshControl.allTargets).toEventually( beEmpty() )
+                expect(refreshControl.allTargets.count) == 0
             }
 			
 			it("unbinds actions for UIBarButtonItem") {

--- a/Tests/iOS-Tests/ButtonTests.swift
+++ b/Tests/iOS-Tests/ButtonTests.swift
@@ -46,8 +46,7 @@ class ButtonTests: QuickSpec {
             var subject = UIButton(type: .system)
 
             subject.rx.action = emptyAction(.just(false))
-            expect(subject.allTargets).toEventuallyNot( beEmpty() )
-            
+            expect(subject.allTargets.count) == 1
             expect(subject.isEnabled) == false
         }
 
@@ -76,7 +75,7 @@ class ButtonTests: QuickSpec {
             subject.rx.action = action
 
             // Setting the action has an asynchronous effect of adding a target.
-            expect(subject.allTargets).toEventuallyNot( beEmpty() )
+            expect(subject.allTargets.count) == 1
 
             subject.test_executeTap()
 

--- a/Tests/iOS-Tests/RefreshControlTests.swift
+++ b/Tests/iOS-Tests/RefreshControlTests.swift
@@ -46,7 +46,7 @@ class RefreshControlTests: QuickSpec {
             var subject = UIRefreshControl()
 
             subject.rx.action = emptyAction(.just(false))
-            expect(subject.allTargets).toEventuallyNot( beEmpty() )
+            expect(subject.allTargets.count) == 1
             
             expect(subject.isEnabled) == false
         }
@@ -76,7 +76,7 @@ class RefreshControlTests: QuickSpec {
             subject.rx.action = action
 
             // Setting the action has an asynchronous effect of adding a target.
-            expect(subject.allTargets).toEventuallyNot( beEmpty() )
+            expect(subject.allTargets.count) == 1
             
             subject.test_executeRefresh()
             


### PR DESCRIPTION
## Flatten out error
Hi all I hope this should close [PR issue 168](https://github.com/RxSwiftCommunity/Action/pull/163) So I went for a KISS solution. 

- [x] Added extension `underlyingError` in order to get `Swift.Error` 
- [x] Added specs to cover claims  
