### PR TITLE
【Test】Syntax sugar to `execute` when Input is Void in iOS-Tests

### DIFF
--- a/Tests/iOS-Tests/AlertActionTests.swift
+++ b/Tests/iOS-Tests/AlertActionTests.swift
@@ -34,7 +34,7 @@ class AlertActionTests: QuickSpec {
 
             subject.rx.action = action
 
-            action.execute(())
+            action.execute()
             expect(subject.isEnabled).toEventually( beFalse() )
 
             observer.onCompleted()

--- a/Tests/iOS-Tests/BarButtonTests.swift
+++ b/Tests/iOS-Tests/BarButtonTests.swift
@@ -35,7 +35,7 @@ class BarButtonTests: QuickSpec {
 			
 			subject.rx.action = action
 			
-			action.execute(())
+			action.execute()
 			expect(subject.isEnabled).toEventually( beFalse() )
 			
 			observer.onCompleted()

--- a/Tests/iOS-Tests/ButtonTests.swift
+++ b/Tests/iOS-Tests/ButtonTests.swift
@@ -35,7 +35,7 @@ class ButtonTests: QuickSpec {
 
             subject.rx.action = action
 
-            action.execute(())
+            action.execute()
             expect(subject.isEnabled).toEventually( beFalse() )
 
             observer.onCompleted()
@@ -122,7 +122,7 @@ class ButtonTests: QuickSpec {
                     }
 
                     subject.rx.action = action
-                    subject.rx.action?.execute(())
+                    subject.rx.action?.execute()
                 }
             }
             

--- a/Tests/iOS-Tests/RefreshControlTests.swift
+++ b/Tests/iOS-Tests/RefreshControlTests.swift
@@ -35,7 +35,7 @@ class RefreshControlTests: QuickSpec {
 
             subject.rx.action = action
 
-            action.execute(())
+            action.execute()
             expect(subject.isEnabled).toEventually( beFalse() )
 
             observer.onCompleted()


### PR DESCRIPTION
Hi all,
I update syntax sugar to ｀execute｀ in iOS-Test.
This is a simple test. 😀

related Pull Request #171