### PR TITLE
Add `completions` property to `CompletableAction`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ Changelog
 
 Current master
 --------------
-- Introdue `completions` property to `CompletableAction`
+- Add `completions` property to `CompletableAction`
 
 3.11.0
 -------

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,10 +4,12 @@ Changelog
 
 Current master
 --------------
+- Introdue `completions` property to `CompletableAction`
+
 3.11.0
 -------
-- Introduction of  `underlyingError` observable which returns a `Swift.Error`  element type. 
-- Updated specs that were breaking in `Circle CI` pipeline 
+- Introduction of  `underlyingError` observable which returns a `Swift.Error`  element type.
+- Updated specs that were breaking in `Circle CI` pipeline
 
 3.10.2
 -------

--- a/Sources/Action/Action+Extensions.swift
+++ b/Sources/Action/Action+Extensions.swift
@@ -21,3 +21,14 @@ public extension Action where Input == Void {
         return execute(())
     }
 }
+
+extension CompletableAction {
+    /// Emits everytime work factory completes.
+    public var completions: Observable<Void> {
+        return executionObservables
+            .flatMap { execution in
+                execution.flatMap {_ in Observable.empty() }
+                    .concat(Observable.just(()))
+        }
+    }
+}

--- a/Sources/Action/Action+Extensions.swift
+++ b/Sources/Action/Action+Extensions.swift
@@ -22,12 +22,12 @@ public extension Action where Input == Void {
     }
 }
 
-extension CompletableAction {
+public extension CompletableAction {
     /// Emits everytime work factory completes.
-    public var completions: Observable<Void> {
+    var completions: Observable<Void> {
         return executionObservables
             .flatMap { execution in
-                execution.flatMap {_ in Observable.empty() }
+                execution.flatMap { _ in Observable.empty() }
                     .concat(Observable.just(()))
         }
     }


### PR DESCRIPTION
This PR fixes #189, it introduces a new observable property to `CompletableAction` extension which will emit a next event every time underlying work factory completes.