### PR TITLE
Nimble specs

### DIFF
--- a/Action.xcodeproj/project.pbxproj
+++ b/Action.xcodeproj/project.pbxproj
@@ -64,6 +64,10 @@
 		C41E08EE2237D26D0039D213 /* Action+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DE00042229758700FB50AB /* Action+Extensions.swift */; };
 		C41E08EF2237D2700039D213 /* Action+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DE00042229758700FB50AB /* Action+Extensions.swift */; };
 		C41E08F02237D2740039D213 /* Action+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DE00042229758700FB50AB /* Action+Extensions.swift */; };
+		C4BFF33D2281D6E100D1AA27 /* Nimble+RxTest+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BFF33C2281D6E100D1AA27 /* Nimble+RxTest+Ext.swift */; };
+		C4BFF33E2281D6E100D1AA27 /* Nimble+RxTest+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BFF33C2281D6E100D1AA27 /* Nimble+RxTest+Ext.swift */; };
+		C4BFF3402282B79F00D1AA27 /* TestEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BFF33F2282B79F00D1AA27 /* TestEvents.swift */; };
+		C4BFF3412282B79F00D1AA27 /* TestEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BFF33F2282B79F00D1AA27 /* TestEvents.swift */; };
 		C4DE00052229758700FB50AB /* Action+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DE00042229758700FB50AB /* Action+Extensions.swift */; };
 		FA3F973C1EDAF46F00A84787 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E21DE28587007E1D0D /* Action.swift */; };
 		FA3F973D1EDAF46F00A84787 /* Action+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0569E01DE28587007E1D0D /* Action+Internal.swift */; };
@@ -143,6 +147,8 @@
 		C41CE72B22283BEE0006E722 /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Build/Mac/RxTest.framework; sourceTree = "<group>"; };
 		C41CE73922283CD00006E722 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/tvOS/RxSwift.framework; sourceTree = "<group>"; };
 		C41CE73F22283D220006E722 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/watchOS/RxSwift.framework; sourceTree = "<group>"; };
+		C4BFF33C2281D6E100D1AA27 /* Nimble+RxTest+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Nimble+RxTest+Ext.swift"; sourceTree = "<group>"; };
+		C4BFF33F2282B79F00D1AA27 /* TestEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEvents.swift; sourceTree = "<group>"; };
 		C4DE00042229758700FB50AB /* Action+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Action+Extensions.swift"; sourceTree = "<group>"; };
 		C4E0263F20D119EE00C8164C /* Action.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Action.podspec; sourceTree = "<group>"; };
 		C4E0264020D11A0F00C8164C /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
@@ -319,6 +325,8 @@
 				3DD965DC1F5DF84800C180FE /* macOS-Tests */,
 				3DD965DB1F5DF83700C180FE /* iOS-Tests */,
 				7F0569F01DE288EB007E1D0D /* ActionTests.swift */,
+				C4BFF33C2281D6E100D1AA27 /* Nimble+RxTest+Ext.swift */,
+				C4BFF33F2282B79F00D1AA27 /* TestEvents.swift */,
 				7F0569F41DE288EB007E1D0D /* Info.plist */,
 			);
 			path = Tests;
@@ -720,7 +728,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				3DD965DE1F5DF8C500C180FE /* BindToTests.swift in Sources */,
+				C4BFF3412282B79F00D1AA27 /* TestEvents.swift in Sources */,
 				3DD965C61F5DC2E100C180FE /* ActionTests.swift in Sources */,
+				C4BFF33E2281D6E100D1AA27 /* Nimble+RxTest+Ext.swift in Sources */,
 				3DD965DF1F5DF8C900C180FE /* NSButtonTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -729,11 +739,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C4BFF3402282B79F00D1AA27 /* TestEvents.swift in Sources */,
 				7F0569F71DE288EB007E1D0D /* BarButtonTests.swift in Sources */,
 				5ED520241E1EA199007621B9 /* BindToTests.swift in Sources */,
 				7F0569F61DE288EB007E1D0D /* AlertActionTests.swift in Sources */,
 				7F0569F51DE288EB007E1D0D /* ActionTests.swift in Sources */,
 				7B4BFE6320C290BF00D72FB0 /* RefreshControlTests.swift in Sources */,
+				C4BFF33D2281D6E100D1AA27 /* Nimble+RxTest+Ext.swift in Sources */,
 				7F0569F81DE288EB007E1D0D /* ButtonTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/ActionTests/ActionTests.swift
+++ b/Tests/ActionTests/ActionTests.swift
@@ -74,20 +74,17 @@ class ActionTests: QuickSpec {
             it("execute on .next") {
                 scheduler.scheduleAt(10) { action.inputs.onNext("a") }
                 scheduler.start()
-                let hasStopEvent = executions.events.filter { $0.value.isStopEvent }.isEmpty
-                expect(hasStopEvent).to(beTrue())
+                expect(executions.events.filter { $0.value.isStopEvent }).to(beEmpty())
             }
             it("ignore .error events") {
                 scheduler.scheduleAt(10) { action.inputs.onError(TestError) }
                 scheduler.start()
-                let hasStopEvent = executions.events.filter { $0.value.isStopEvent }.isEmpty
-                expect(hasStopEvent).to(beTrue())
+                expect(executions.events.filter { $0.value.isStopEvent }).to(beEmpty())
             }
             it("ignore .completed events") {
                 scheduler.scheduleAt(10) { action.inputs.onCompleted() }
                 scheduler.start()
-                let hasStopEvent = executions.events.filter { $0.value.isStopEvent }.isEmpty
-                expect(hasStopEvent).to(beTrue())
+                expect(executions.events.filter { $0.value.isStopEvent }).to(beEmpty())
                 expect(inputs.events.isEmpty).to(beTrue())
             }
             it("accept multiple .next events") {

--- a/Tests/Nimble+RxTest+Ext.swift
+++ b/Tests/Nimble+RxTest+Ext.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Tests/Nimble+RxTest+Ext.swift
+++ b/Tests/Nimble+RxTest+Ext.swift
@@ -24,3 +24,16 @@ extension Event {
     }
 }
 
+/// Nimble
+
+extension PredicateResult {
+    static var evaluationFailed: PredicateResult {
+        return PredicateResult(status: .doesNotMatch,
+                               message: .fail("failed to evaluate given expression"))
+    }
+    
+    static func isEqual<T: Equatable>(actual: T?, expected: T?) -> PredicateResult {
+        return PredicateResult(bool: actual == expected,
+                               message: .expectedCustomValueTo("get <\(expected.asString())>", "<\(actual.asString())>"))
+    }
+}

--- a/Tests/Nimble+RxTest+Ext.swift
+++ b/Tests/Nimble+RxTest+Ext.swift
@@ -12,3 +12,15 @@ extension Optional {
         return String(describing: s)
     }
 }
+
+/// `RxSwift`
+
+extension Event {
+    var isError: Bool {
+        switch self {
+        case .error: return true
+        default: return false
+        }
+    }
+}
+

--- a/Tests/Nimble+RxTest+Ext.swift
+++ b/Tests/Nimble+RxTest+Ext.swift
@@ -1,1 +1,14 @@
 import Foundation
+import Quick
+import Nimble
+import RxSwift
+import RxTest
+
+/// `Foundation`
+
+extension Optional {
+    func asString() -> String {
+        guard let s = self else { return "nil" }
+        return String(describing: s)
+    }
+}

--- a/Tests/Nimble+RxTest+Ext.swift
+++ b/Tests/Nimble+RxTest+Ext.swift
@@ -52,3 +52,25 @@ public func match<T: Equatable>(_ expected: T) -> Predicate<T> {
         return PredicateResult(bool: true, message: .fail("matched values and timeline as expected"))
     }
 }
+
+public func match<T>(_ expected: [Recorded<Event<T>>]) -> Predicate<[Recorded<Event<T>>]> where T: Equatable {
+    return Predicate { events in
+        
+        guard let source = try events.evaluate() else {
+            return PredicateResult.evaluationFailed
+        }
+        guard source.count == expected.count else {
+            return PredicateResult(bool: false, message: .expectedCustomValueTo("get <\(expected.count)> events", "<\(source.count)> events"))
+        }
+        
+        for (lhs, rhs) in zip(source, expected) {
+            guard lhs.time == rhs.time,
+                lhs.value == rhs.value else {
+                    return PredicateResult(bool: rhs == lhs, message: .expectedCustomValueTo("match <\(rhs)>", "<\(lhs)>"))
+            }
+            continue
+        }
+        
+        return PredicateResult(bool: true, message: .fail("match timeline"))
+    }
+}

--- a/Tests/Nimble+RxTest+Ext.swift
+++ b/Tests/Nimble+RxTest+Ext.swift
@@ -38,14 +38,15 @@ extension PredicateResult {
     }
 }
 
-public func match<T: Equatable>(_ expected: T) -> Predicate<T> {
+public func match<T>(_ expected: T) -> Predicate<T> where T: Equatable {
     return Predicate { events in
         
         guard let source = try events.evaluate() else {
             return PredicateResult.evaluationFailed
         }
         guard source == expected else {
-            return PredicateResult(status: .doesNotMatch, message: .expectedCustomValueTo("get <\(expected)> events", "<\(source)> events"))
+            return PredicateResult(status: .doesNotMatch,
+                                   message: .expectedCustomValueTo("get <\(expected)> events", "<\(source)> events"))
         }
         
         
@@ -60,13 +61,15 @@ public func match<T>(_ expected: [Recorded<Event<T>>]) -> Predicate<[Recorded<Ev
             return PredicateResult.evaluationFailed
         }
         guard source.count == expected.count else {
-            return PredicateResult(bool: false, message: .expectedCustomValueTo("get <\(expected.count)> events", "<\(source.count)> events"))
+            return PredicateResult(bool: false,
+                                   message: .expectedCustomValueTo("get <\(expected.count)> events", "<\(source.count)> events"))
         }
         
         for (lhs, rhs) in zip(source, expected) {
             guard lhs.time == rhs.time,
                 lhs.value == rhs.value else {
-                    return PredicateResult(bool: rhs == lhs, message: .expectedCustomValueTo("match <\(rhs)>", "<\(lhs)>"))
+                    return PredicateResult(bool: rhs == lhs,
+                                           message: .expectedCustomValueTo("match <\(rhs)>", "<\(lhs)>"))
             }
             continue
         }
@@ -84,7 +87,8 @@ public func match<T, E: Error>(with expectedErrors: [Recorded<Event<E>>]) -> Pre
         for (lhs, rhs) in zip(errorEvents, expectedErrors) {
             guard lhs.time == rhs.time,
                 lhs.value.error.asString() == rhs.value.error.asString() else {
-                return PredicateResult(bool: false, message: .fail("did not error"))
+                return PredicateResult(bool: false,
+                                       message: .fail("did not error"))
             }
             continue
         }

--- a/Tests/Nimble+RxTest+Ext.swift
+++ b/Tests/Nimble+RxTest+Ext.swift
@@ -37,3 +37,18 @@ extension PredicateResult {
                                message: .expectedCustomValueTo("get <\(expected.asString())>", "<\(actual.asString())>"))
     }
 }
+
+public func match<T: Equatable>(_ expected: T) -> Predicate<T> {
+    return Predicate { events in
+        
+        guard let source = try events.evaluate() else {
+            return PredicateResult.evaluationFailed
+        }
+        guard source == expected else {
+            return PredicateResult(status: .doesNotMatch, message: .expectedCustomValueTo("get <\(expected)> events", "<\(source)> events"))
+        }
+        
+        
+        return PredicateResult(bool: true, message: .fail("matched values and timeline as expected"))
+    }
+}

--- a/Tests/TestEvents.swift
+++ b/Tests/TestEvents.swift
@@ -1,0 +1,2 @@
+import Foundation
+

--- a/Tests/TestEvents.swift
+++ b/Tests/TestEvents.swift
@@ -1,2 +1,91 @@
 import Foundation
+import RxSwift
+import RxTest
+@testable import Action
 
+enum TestEvents {
+    static let inputs = Recorded.events([
+        .next(10, "a"),
+        .next(20, "b"),
+        ])
+
+    static let elements = Recorded.events([
+        .next(10, "a"),
+        .next(20, "b"),
+        ])
+    
+    static let multipleElements = Recorded.events([
+        .next(10, "a"),
+        .next(10, "b"),
+        .next(10, "c"),
+        .next(20, "b"),
+        .next(20, "c"),
+        .next(20, "d"),
+        ])
+
+    static let enabled =  Recorded.events([
+        .next(0, true),
+        .next(10, false),
+        .next(10, true),
+        .next(20, false),
+        .next(20, true),
+        ])
+
+    static let disabled = Recorded.events([
+        .next(0, true),
+        .next(10, false),
+        .next(10, true),
+        .next(20, false),
+        .next(20, true),
+        ])
+
+    static let executing = Recorded.events([
+        .next(0, false),
+        .next(10, true),
+        .next(10, false),
+        .next(20, true),
+        .next(20, false),
+        ])
+    
+    static let `false` = Recorded.events([
+        .next(0, false),
+        ])
+
+    static let underlyingErrors = Recorded.events([
+        .next(10, ActionError.underlyingError(TestError)),
+        .next(20, ActionError.underlyingError(TestError)),
+        ])
+    
+    static let notEnabledErrors = Recorded.events([
+        .next(10, ActionError.notEnabled),
+        .next(20, ActionError.notEnabled),
+        ])
+    
+    static let executionStreams = Recorded.events([
+        .next(10, "a"),
+        .completed(10),
+        .next(20, "b"),
+        .completed(20),
+        ])
+    
+    static let elementUnderlyingErrors = Recorded.events([
+        .error(10, ActionError.underlyingError(TestError), String.self),
+        .error(20, ActionError.underlyingError(TestError), String.self),
+        ])
+
+    static let elementNotEnabledErrors = Recorded.events([
+        .error(10, ActionError.notEnabled, String.self),
+        .error(20, ActionError.notEnabled, String.self),
+        ])
+    
+    static let multipleExecutionStreams = Recorded.events([
+        .next(10, "a"),
+        .next(10, "a"),
+        .next(10, "a"),
+        .completed(10),
+        .next(20, "b"),
+        .next(20, "b"),
+        .next(20, "b"),
+        .completed(20),
+        ])
+}

--- a/Tests/iOS-Tests/AlertActionTests.swift
+++ b/Tests/iOS-Tests/AlertActionTests.swift
@@ -8,22 +8,16 @@ class AlertActionTests: QuickSpec {
     override func spec() {
         it("is nil by default") {
             let subject = UIAlertAction.Action("Hi", style: .default)
-            expect(subject.rx.action).to( beNil() )
+            expect(subject.rx.action).to(beNil())
         }
-
         it("respects setter") {
             var subject = UIAlertAction.Action("Hi", style: .default)
-
             let action = emptyAction()
-
             subject.rx.action = action
-
-            expect(subject.rx.action) === action
+            expect(subject.rx.action).to(beAKindOf(CocoaAction.self))
         }
-
         it("disables the alert action while executing") {
             var subject = UIAlertAction.Action("Hi", style: .default)
-
             var observer: AnyObserver<Void>!
             let action = CocoaAction(workFactory: { _ in
                 return Observable.create { (obsv) -> Disposable in
@@ -33,7 +27,6 @@ class AlertActionTests: QuickSpec {
             })
 
             subject.rx.action = action
-
             action.execute()
             expect(subject.isEnabled).toEventually( beFalse() )
 
@@ -55,7 +48,7 @@ class AlertActionTests: QuickSpec {
                     .disposed(by: disposeBag)
             }
 
-            expect(subject.isEnabled) == false
+            expect(subject.isEnabled).to(beFalse())
         }
 
         it("disposes of old action subscriptions when re-set") {
@@ -77,8 +70,7 @@ class AlertActionTests: QuickSpec {
             }
 
             subject.rx.action = nil
-
-            expect(disposed) == true
+            expect(disposed).to(beTrue())
         }
     }
 }

--- a/Tests/iOS-Tests/BarButtonTests.swift
+++ b/Tests/iOS-Tests/BarButtonTests.swift
@@ -16,10 +16,8 @@ class BarButtonTests: QuickSpec {
 			var subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
 
 			let action = emptyAction()
-
 			subject.rx.action = action
-
-			expect(subject.rx.action) === action
+            expect(subject.rx.action).to(beAKindOf(CocoaAction.self))
 		}
 
 		it("disables the button while executing") {
@@ -46,9 +44,8 @@ class BarButtonTests: QuickSpec {
 			var subject = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
 
 			subject.rx.action = emptyAction(.just(false))
-            expect(subject.target).toEventuallyNot( beNil() )
-
-			expect(subject.isEnabled) == false
+            expect(subject.target).toEventuallyNot(beNil())
+			expect(subject.isEnabled).to(beFalse())
 		}
 
 		it("doesn't execute a disabled action when tapped") {
@@ -61,7 +58,6 @@ class BarButtonTests: QuickSpec {
 			})
 
 			_ = subject.target?.perform(subject.action, with: subject)
-
 			expect(executed) == false
 		}
 
@@ -75,11 +71,9 @@ class BarButtonTests: QuickSpec {
 			})
 			subject.rx.action = action
             // Setting the action has the asynchronous effect of adding a target.
-            expect(subject.target).toEventuallyNot( beNil() )
-
+            expect(subject.target).toEventuallyNot(beNil())
 			_ = subject.target?.perform(subject.action, with: subject)
-
-			expect(executed) == true
+			expect(executed).to(beTrue())
 		}
 
 		it("disposes of old action subscriptions when re-set") {
@@ -101,8 +95,7 @@ class BarButtonTests: QuickSpec {
 			}
 
 			subject.rx.action = nil
-
-			expect(disposed) == true
+			expect(disposed).to(beTrue())
 		}
 	}
 }


### PR DESCRIPTION
## Specs Cleanup

I just wanted to re-order the `ActionTests` and to fully use `Quick+Nimble` matchers where possible and to avoid totally `XCT`

- [x] Introduced `Nimble-Matchers` for the specs 
- [x] Overhaul of entire specs
- [x] Dropped the use of `XCT`
- [x] Cosmetic updates to the specs 