### PR TITLE
Add support for RxSwift 6

### DIFF
--- a/Action.podspec
+++ b/Action.podspec
@@ -22,8 +22,8 @@ Pod::Spec.new do |s|
   s.swift_version   =   '5.0'
 
   s.frameworks  = "Foundation"
-  s.dependency "RxSwift", "~> 5.0"
-  s.dependency "RxCocoa", "~> 5.0"
+  s.dependency "RxSwift", ">= 5.0", "< 7.0"
+  s.dependency "RxCocoa", ">= 5.0", "< 7.0"
 
   s.watchos.exclude_files = "Control+Action.swift", "Button+Action.swift", "UIBarButtonItem+Action.swift", "UIAlertAction+Action.swift"
   s.osx.exclude_files = "UIBarButtonItem+Action.swift", "UIAlertAction+Action.swift"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" ~> 5.0
+github "ReactiveX/RxSwift" >= 5.0 # < 7.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v8.1.1"
+github "Quick/Nimble" "v9.0.0"
 github "Quick/Quick" "v3.0.0"
 github "ReactiveX/RxSwift" "5.1.1"

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ Changelog
 Current master
 --------------
 
-- Nothing yet!
+- Add support for RxSwift 6.0.
 
 4.1.0
 -----

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "b3e888b4972d9bc76495dd74d30a8c7fad4b9395",
-          "version": "5.0.1"
+          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
+          "version": "5.1.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["Action"]),
         ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.0")
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", "5.0.0" ..< "7.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Tests/Nimble+RxTest+Ext.swift
+++ b/Tests/Nimble+RxTest+Ext.swift
@@ -34,7 +34,7 @@ extension PredicateResult {
     
     static func isEqual<T: Equatable>(actual: T?, expected: T?) -> PredicateResult {
         return PredicateResult(bool: actual == expected,
-                               message: .expectedCustomValueTo("get <\(expected.asString())>", "<\(actual.asString())>"))
+                               message: .expectedCustomValueTo("get <\(expected.asString())>", actual: "<\(actual.asString())>"))
     }
 }
 
@@ -46,7 +46,7 @@ public func match<T>(_ expected: T) -> Predicate<T> where T: Equatable {
         }
         guard source == expected else {
             return PredicateResult(status: .doesNotMatch,
-                                   message: .expectedCustomValueTo("get <\(expected)> events", "<\(source)> events"))
+                                   message: .expectedCustomValueTo("get <\(expected)> events", actual: "<\(source)> events"))
         }
         
         
@@ -62,14 +62,14 @@ public func match<T>(_ expected: [Recorded<Event<T>>]) -> Predicate<[Recorded<Ev
         }
         guard source.count == expected.count else {
             return PredicateResult(bool: false,
-                                   message: .expectedCustomValueTo("get <\(expected.count)> events", "<\(source.count)> events"))
+                                   message: .expectedCustomValueTo("get <\(expected.count)> events", actual: "<\(source.count)> events"))
         }
         
         for (lhs, rhs) in zip(source, expected) {
             guard lhs.time == rhs.time,
                 lhs.value == rhs.value else {
                     return PredicateResult(bool: rhs == lhs,
-                                           message: .expectedCustomValueTo("match <\(rhs)>", "<\(lhs)>"))
+                                           message: .expectedCustomValueTo("match <\(rhs)>", actual: "<\(lhs)>"))
             }
             continue
         }

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ jobs:
       XCODE_TEST_REPORTS: /tmp/xcode-test-results
       LANG: en_US.UTF-8
     macos:
-      xcode: "11.3.0"
+      xcode: "11.7.0"
     steps:
       - checkout
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS $XCODE_TEST_REPORTS

--- a/circle.yml
+++ b/circle.yml
@@ -30,57 +30,57 @@ jobs:
           command: >
             set -o pipefail && xcodebuild test SWIFT_VERSION=5.0
             -workspace Action.xcworkspace
-            -scheme 'Action' -sdk iphonesimulator
-            -destination "name=iPhone 11" | xcpretty -c --test
+            -scheme 'Action'
+            -destination "platform=iOS Simulator,name=iPhone 11" | xcpretty -c --test
       - run:
           name: Run Tests (Swift 4.2)
           command: >
             set -o pipefail && xcodebuild test SWIFT_VERSION=4.2
             -workspace Action.xcworkspace
-            -scheme 'Action' -sdk iphonesimulator
-            -destination "name=iPhone 11" | xcpretty -c --test
+            -scheme 'Action'
+            -destination "platform=iOS Simulator,name=iPhone 11" | xcpretty -c --test
       - run:
           name: Build  watchOS (Swift 5.0)
           command: >
             set -o pipefail && xcodebuild build SWIFT_VERSION=5.0
             -workspace Action.xcworkspace
-            -scheme Action-watchOS -sdk watchsimulator
-            -destination "name=Apple Watch Series 5 - 44mm" | xcpretty -c
+            -scheme Action-watchOS
+            -destination "platform=watchOS Simulator,name=Apple Watch Series 5 - 44mm" | xcpretty -c
       - run:
           name: Build  watchOS (Swift 4.2)
           command: >
             set -o pipefail && xcodebuild build SWIFT_VERSION=4.2
             -workspace Action.xcworkspace
-            -scheme Action-watchOS -sdk watchsimulator
-            -destination "name=Apple Watch Series 5 - 44mm" | xcpretty -c
+            -scheme Action-watchOS
+            -destination "platform=watchOS Simulator,name=Apple Watch Series 5 - 44mm" | xcpretty -c
       - run:
           name: Build  macOS (Swift 5.0)
           command: >
             set -o pipefail && xcodebuild build SWIFT_VERSION=5.0
             -workspace Action.xcworkspace
-            -scheme Action-macOS -sdk macosx
+            -scheme Action-macOS
             -destination "arch=x86_64" | xcpretty -c
       - run:
           name: Build  macOS (Swift 4.2)
           command: >
             set -o pipefail && xcodebuild build SWIFT_VERSION=4.2
             -workspace Action.xcworkspace
-            -scheme Action-macOS -sdk macosx
+            -scheme Action-macOS
             -destination "arch=x86_64" | xcpretty -c
       - run:
           name: Build  tvOS (Swift 5.0)
           command: >
             set -o pipefail && xcodebuild build SWIFT_VERSION=5.0
             -workspace Action.xcworkspace
-            -scheme Action-tvOS -sdk appletvsimulator
-            -destination "name=Apple TV 4K (at 1080p)" | xcpretty -c
+            -scheme Action-tvOS
+            -destination "platform=tvOS Simulator,name=Apple TV 4K (at 1080p)" | xcpretty -c
       - run:
           name: Build  tvOS (Swift 4.2)
           command: >
             set -o pipefail && xcodebuild build SWIFT_VERSION=4.2
             -workspace Action.xcworkspace
-            -scheme Action-tvOS -sdk appletvsimulator
-            -destination "name=Apple TV 4K (at 1080p)" | xcpretty -c
+            -scheme Action-tvOS
+            -destination "platform=tvOS Simulator,name=Apple TV 4K (at 1080p)" | xcpretty -c
       - store_artifacts:
           path: /tmp/xcode-test-results
 workflows:


### PR DESCRIPTION
RxSwift 6 (as of [6.0.0-rc.1](https://github.com/ReactiveX/RxSwift/releases/tag/6.0.0-rc.1)) doesn't introduce any source-breaking changes that affect Action, so it's safe to extend our version compatibility to include both RxSwift 5 and 6.