### PR TITLE
[Swift Package] Add minimum platform version to conform to RxSwift dependency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@ Current master
 
 - Nothing yet!
 
+4.2.1
+-----
+
+- Add miminum platform requirements to Swift Package.
+
 4.2.0
 -----
 

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["Action"]),
         ],
     dependencies: [
-        .package(url: "https://github.com/appcraftstudio/Action.git", "5.0.0" ..< "7.0.0"),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", "5.0.0" ..< "7.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "Action",
+    platforms: [
+        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["Action"]),
         ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", "5.0.0" ..< "7.0.0"),
+        .package(url: "https://github.com/appcraftstudio/Action.git", "5.0.0" ..< "7.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Action framework needs to specify its minimum platforms versions to be sure they don't conflict with its dependency ones.

<img width="409" alt="Screenshot 2020-12-15 at 15 25 25" src="https://user-images.githubusercontent.com/4943835/102227392-cea2a600-3ee9-11eb-8c30-bacc83d608a2.png">