### PR TITLE
breakRetainCycle: Break retain cycle in bind(to:input:)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ Changelog
 Current master
 --------------
 
-- Nothing yet!
+- Break retain cycle in `bind(to:input:)`
 
 4.3.0
 -----

--- a/Sources/Action/CommonUI/Control+Action.swift
+++ b/Sources/Action/CommonUI/Control+Action.swift
@@ -20,7 +20,9 @@ public extension Reactive where Base: Control {
 
 		// For each tap event, use the inputTransform closure to provide an Input value to the action
 		controlEvent
-			.map { inputTransform(self.base) }
+            .withUnretained(self.base)
+            .map(\.0)
+            .map(inputTransform)
 			.bind(to: action.inputs)
 			.disposed(by: self.base.actionDisposeBag)
 

--- a/Sources/Action/CommonUI/Control+Action.swift
+++ b/Sources/Action/CommonUI/Control+Action.swift
@@ -20,9 +20,9 @@ public extension Reactive where Base: Control {
 
 		// For each tap event, use the inputTransform closure to provide an Input value to the action
 		controlEvent
-            .withUnretained(self.base)
-            .map(\.0)
-            .map(inputTransform)
+			.withUnretained(self.base)
+			.map(\.0)
+			.map(inputTransform)
 			.bind(to: action.inputs)
 			.disposed(by: self.base.actionDisposeBag)
 

--- a/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
+++ b/Sources/Action/UIKitExtensions/UIBarButtonItem+Action.swift
@@ -42,7 +42,9 @@ public extension Reactive where Base: UIBarButtonItem {
         unbindAction()
 
         self.tap
-            .map { inputTransform(self.base) }
+            .withUnretained(self.base)
+            .map(\.0)
+            .map(inputTransform)
             .bind(to: action.inputs)
             .disposed(by: self.base.actionDisposeBag)
 

--- a/Sources/Action/UIKitExtensions/UIRefreshControl+Action.swift
+++ b/Sources/Action/UIKitExtensions/UIRefreshControl+Action.swift
@@ -34,7 +34,9 @@ public extension Reactive where Base: UIRefreshControl {
         unbindAction()
 
         self.controlEvent(.valueChanged)
-            .map { inputTransform(self.base)}
+            .withUnretained(self.base)
+            .map(\.0)
+            .map(inputTransform)
             .bind(to: action.inputs)
             .disposed(by: self.base.actionDisposeBag)
 

--- a/Tests/iOS-Tests/BindToTests.swift
+++ b/Tests/iOS-Tests/BindToTests.swift
@@ -45,18 +45,18 @@ class BindToTests: QuickSpec {
 			expect(called).toEventually( beTrue() )
 		}
 
-        it("does not retain UIButton") {
-          var button: UIButton? = UIButton()
-          let action = Action<String, String>(workFactory: { _ in
-              return .empty()
-          })
-          button?.rx.bind(to: action, input: "Hi there!")
+		it("does not retain UIButton") {
+			var button: UIButton? = UIButton()
+			let action = Action<String, String>(workFactory: { _ in
+				return .empty()
+			})
+			button?.rx.bind(to: action, input: "Hi there!")
 
-          weak var buttonWeakReference = button
-          button = nil
+			weak var buttonWeakReference = button
+			button = nil
 
-          expect(buttonWeakReference).to(beNil())
-        }
+			expect(buttonWeakReference).to(beNil())
+		}
 
 		it("activates a generic control event") {
 			var called = false

--- a/Tests/iOS-Tests/BindToTests.swift
+++ b/Tests/iOS-Tests/BindToTests.swift
@@ -45,6 +45,19 @@ class BindToTests: QuickSpec {
 			expect(called).toEventually( beTrue() )
 		}
 
+        it("does not retain UIButton") {
+          var button: UIButton? = UIButton()
+          let action = Action<String, String>(workFactory: { _ in
+              return .empty()
+          })
+          button?.rx.bind(to: action, input: "Hi there!")
+
+          weak var buttonWeakReference = button
+          button = nil
+
+          expect(buttonWeakReference).to(beNil())
+        }
+
 		it("activates a generic control event") {
 			var called = false
 			let button = UIButton()
@@ -74,6 +87,20 @@ class BindToTests: QuickSpec {
 
 			expect(called).toEventually( beTrue() )
 		}
+
+        it("does not retain UIBarButtonItem") {
+          var barButtonItem: UIBarButtonItem? = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
+          let action = Action<String, String>(workFactory: { _ in
+              return .empty()
+          })
+          barButtonItem?.rx.bind(to: action, input: "Hi there!")
+
+          weak var barButtonItemWeakReference = barButtonItem
+          barButtonItem = nil
+
+          expect(barButtonItemWeakReference).to(beNil())
+        }
+
         it("actives a UIRefreshControl") {
             var called = false
             let item = UIRefreshControl()
@@ -86,6 +113,19 @@ class BindToTests: QuickSpec {
             item.test_executeRefresh()
 
             expect(called).toEventually( beTrue() )
+        }
+
+        it("does not retain UIRefreshControl") {
+          var refreshControl: UIRefreshControl? = UIRefreshControl()
+          let action = Action<String, String>(workFactory: { _ in
+              return .empty()
+          })
+          refreshControl?.rx.bind(to: action, input: "Hi there!")
+
+          weak var refreshControlWeakReference = refreshControl
+          refreshControl = nil
+
+          expect(refreshControlWeakReference).to(beNil())
         }
 
 		describe("unbinding") {


### PR DESCRIPTION
https://github.com/RxSwiftCommunity/Action/issues/227

This pull request breaks the retain cycle in the various `bind(to:input:)` methods. Tests have also been added to ensure no retain cycle is introduced by calling `bind(to:input:)`.