### PR TITLE
Flatted the nested ActionError

### DIFF
--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -84,8 +84,13 @@ public final class Action<Input, Element> {
             .flatMap { input, enabled -> Observable<Observable<Element>> in
                 if enabled {
                     return Observable.of(workFactory(input)
-                                             .do(onError: { errorsSubject.onNext(.underlyingError($0)) })
-                                             .share(replay: 1, scope: .forever))
+                        .do(onError: { error in
+                            if let error = error as? ActionError {
+                                errorsSubject.onNext(error)
+                            } else {
+                                errorsSubject.onNext(.underlyingError(error))
+                            }
+                        }).share(replay: 1, scope: .forever))
                 } else {
                     errorsSubject.onNext(.notEnabled)
                     return Observable.empty()


### PR DESCRIPTION
When use the Action nest in another Action, it will underlyingError the error two times. 

So , I think it's better underlyingError once.