### PR TITLE
Fix `Actions.elements` does not emit values 

### DIFF
--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -95,6 +95,7 @@ public final class Action<Input, Element> {
 
         elements = executionObservables
             .flatMap { $0.catch { _ in Observable.empty() } }
+            .share()
 
         executing = executionObservables.flatMap {
                 execution -> Observable<Bool> in
@@ -112,6 +113,10 @@ public final class Action<Input, Element> {
         Observable
             .combineLatest(executing, enabledIf) { !$0 && $1 }
             .bind(to: enabledSubject)
+            .disposed(by: disposeBag)
+
+        elements
+            .subscribe()
             .disposed(by: disposeBag)
     }
 


### PR DESCRIPTION
Fixed #216

I encountered a case similar to the issue ( #216 ) and committed testing and a temporary fix. It seems that the values does not emit if the timing to subscribe the elements is after the input.

I don't think this fix is so good, so does anyone have any other ideas?
