### PR TITLE
Use PublishRelay instead of PublishSubject

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Current master
 --------------
 
 - Break retain cycle in `bind(to:input:)`
+- Use PublishRelay instead of PublishSubject 
 
 4.3.0
 -----


### PR DESCRIPTION
#trivial
- `errorsSubject` and `inputsSubject` call only `onNext(_ element:)` 
- Replaced from `PublishSubject` to `PublishRelay `