### PR TITLE
Filter out errors from `CompletableAction.completions`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Changelog
 Current master
 --------------
 
+- Avoid from getting errors in `CompletableAction.completions`
 - Break retain cycle in `bind(to:input:)`
 - Use PublishRelay instead of PublishSubject 
 

--- a/Sources/Action/Action+Extensions.swift
+++ b/Sources/Action/Action+Extensions.swift
@@ -27,8 +27,10 @@ public extension CompletableAction {
     var completions: Observable<Void> {
         return executionObservables
             .flatMap { execution in
-                execution.flatMap { _ in Observable.empty() }
-                    .concat(Observable.just(()))
-        }
+                execution.flatMap { _ in Observable<Void?>.empty() }
+                    .concat(Observable<Void?>.just(()))
+                    .catchAndReturn(nil)
+            }
+            .compactMap { $0 }
     }
 }


### PR DESCRIPTION
**Problem statement**
`CompletableAction` is usually used in some repeatable manner. Each action can finish with an error especially if there's a network request or a validation process inside the `workFactory`. So far `completions` emits these errors which in turn disposes existing subscriptions to this observable.

**Proposed solution**
Catch errors in `completions`.
#trivial