### PR TITLE
List RxRelay as a dependency in SPM's Package file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Action",
-            dependencies: ["RxSwift", "RxCocoa"],
+            dependencies: ["RxSwift", "RxCocoa", "RxRelay"],
             path: "Sources/Action")
     ]
 )

--- a/Sources/Action/Action.swift
+++ b/Sources/Action/Action.swift
@@ -1,6 +1,7 @@
 import Foundation
 import RxSwift
 import RxCocoa
+import RxRelay
 
 /// Typealias for compatibility with UIButton's rx.action property.
 public typealias CocoaAction = Action<Void, Void>


### PR DESCRIPTION
#trivial

(The issue reproduces with the version 5.0.0 (55f5da0) on Xcode 15 and 16.)

I occasionally get the following linker errors while building the project where Action is imported via Swift Package Manager:

```
Undefined symbols for architecture arm64:
  "RxRelay.PublishRelay.asObservable() -> RxSwift.Observable<A>", referenced from:
      Action.Action.init(enabledIf: RxSwift.Observable<Swift.Bool>, workFactory: (A) -> RxSwift.Observable<B>) -> Action.Action<A, B> in Action.o
  "RxRelay.PublishRelay.accept(A) -> ()", referenced from:
      closure #1 (RxSwift.Event<A>) -> () in Action.Action.init(enabledIf: RxSwift.Observable<Swift.Bool>, workFactory: (A) -> RxSwift.Observable<B>) -> Action.Action<A, B> in Action.o
      closure #3 (A, Swift.Bool) -> RxSwift.Observable<RxSwift.Observable<B>> in Action.Action.init(enabledIf: RxSwift.Observable<Swift.Bool>, workFactory: (A) -> RxSwift.Observable<B>) -> Action.Action<A, B> in Action.o
      closure #1 (Swift.Error) -> () in closure #3 (A, Swift.Bool) -> RxSwift.Observable<RxSwift.Observable<B>> in Action.Action.init(enabledIf: RxSwift.Observable<Swift.Bool>, workFactory: (A) -> RxSwift.Observable<B>) -> Action.Action<A, B> in Action.o
  "RxRelay.PublishRelay.__allocating_init() -> RxRelay.PublishRelay<A>", referenced from:
      Action.Action.init(enabledIf: RxSwift.Observable<Swift.Bool>, workFactory: (A) -> RxSwift.Observable<B>) -> Action.Action<A, B> in Action.o
      Action.Action.init(enabledIf: RxSwift.Observable<Swift.Bool>, workFactory: (A) -> RxSwift.Observable<B>) -> Action.Action<A, B> in Action.o
  "type metadata accessor for RxRelay.PublishRelay", referenced from:
      Action.Action.init(enabledIf: RxSwift.Observable<Swift.Bool>, workFactory: (A) -> RxSwift.Observable<B>) -> Action.Action<A, B> in Action.o
  "nominal type descriptor for RxRelay.PublishRelay", referenced from:
      _symbolic _____y_____G 7RxRelay07PublishB0C 6Action0D5ErrorO in Action.o
      _symbolic _____yxG 7RxRelay07PublishB0C in Action.o
  "protocol conformance descriptor for RxRelay.PublishRelay<A> : RxSwift.ObservableType in RxRelay", referenced from:
      Action.Action.init(enabledIf: RxSwift.Observable<Swift.Bool>, workFactory: (A) -> RxSwift.Observable<B>) -> Action.Action<A, B> in Action.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The problem is intermittent and resetting package caches fixes it. Still, for the sake of correctness, I propose to list RxRelay as a dependency, just like RxCocoa.